### PR TITLE
Logging appointment delete in calendar

### DIFF
--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -1,19 +1,19 @@
 <?php
-/** 
-* library/patient_tracker.inc.php Functions used in the Patient Flow Board. 
-* 
+/**
+* library/patient_tracker.inc.php Functions used in the Patient Flow Board.
+*
 * Functions for use in the Patient Flow Board and Patient Flow Board Reports.
-* 
-* 
-* Copyright (C) 2015-2017 Terry Hill <teryhill@librehealth.io> 
-* 
+*
+*
+* Copyright (C) 2015-2017 Terry Hill <teryhill@librehealth.io>
+*
 * LICENSE: This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0
-* See the Mozilla Public License for more details. 
+* See the Mozilla Public License for more details.
 * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
-* 
-* @package LibreEHR 
+*
+* @package LibreEHR
 * @author Terry Hill <teryhill@librehealth.io>
-* @link http://www.libreehr.org 
+* @link http://www.libreehr.org
 *
 * Please help the overall project by sending changes you make to the author and to the LibreEHR community.
 *
@@ -25,116 +25,116 @@ function get_Tracker_Time_Interval ($tracker_from_time, $tracker_to_time, $allow
     $tracker_time_calc = strtotime($tracker_to_time) - strtotime($tracker_from_time);
 
     $tracker_time = "";
-    if ($tracker_time_calc > 60*60*24) {        
+    if ($tracker_time_calc > 60*60*24) {
         $days = floor($tracker_time_calc/60/60/24);
-        if($days >= 2){   
-          $tracker_time .=  "$days ". xl('days'); 
+        if($days >= 2){
+          $tracker_time .=  "$days ". xl('days');
         }
         else
         {
-          $tracker_time .=  "$days ". xl('day');   
+          $tracker_time .=  "$days ". xl('day');
         }
-        $tracker_time_calc = $tracker_time_calc - ($days * (60*60*24));        
+        $tracker_time_calc = $tracker_time_calc - ($days * (60*60*24));
     }
     if ($tracker_time_calc > 60*60) {
         $hours = floor($tracker_time_calc/60/60);
         if(strlen($days != 0)) {
-          if($hours >= 2){   
-             $tracker_time .=  ", $hours " . xl('hours'); 
+          if($hours >= 2){
+             $tracker_time .=  ", $hours " . xl('hours');
           }
           else
           {
-             $tracker_time .=  ", $hours " . xl('hour');   
+             $tracker_time .=  ", $hours " . xl('hour');
           }
         }
         else
         {
-          if($hours >= 2){ 
+          if($hours >= 2){
              $tracker_time .=  "$hours " . xl('hours');
           }
           else
           {
-             $tracker_time .=  "$hours " . xl('hour');   
+             $tracker_time .=  "$hours " . xl('hour');
           }
         }
-        $tracker_time_calc = $tracker_time_calc - ($hours * (60*60));        
+        $tracker_time_calc = $tracker_time_calc - ($hours * (60*60));
     }
-    if ($allow_sec) { 
+    if ($allow_sec) {
      if ($tracker_time_calc > 60) {
         $minutes = floor($tracker_time_calc/60);
         if(strlen($hours != 0)) {
-          if($minutes >= 2){   
+          if($minutes >= 2){
             $tracker_time .=  ", $minutes " . xl('minutes');
           }
           else
           {
             $tracker_time .=  ", $minutes " . xl('minute');
-          }          
+          }
          }
         else
-        {  
-          if($minutes >= 2){     
-            $tracker_time .=  "$minutes " . xl('minutes'); 
+        {
+          if($minutes >= 2){
+            $tracker_time .=  "$minutes " . xl('minutes');
           }
           else
           {
-            $tracker_time .=  "$minutes " . xl('minute'); 
-          }          
-        }        
-        $tracker_time_calc = $tracker_time_calc - ($minutes * 60);        
+            $tracker_time .=  "$minutes " . xl('minute');
+          }
+        }
+        $tracker_time_calc = $tracker_time_calc - ($minutes * 60);
      }
     }
     else
     {
        $minutes = round($tracker_time_calc/60);
         if(strlen($hours != 0)) {
-          if($minutes >= 2){   
+          if($minutes >= 2){
             $tracker_time .=  ", $minutes " . xl('minutes');
           }
           else
           {
             $tracker_time .=  ", $minutes " . xl('minute');
-          }          
-         }
-        else
-        {  
-          if($minutes >= 2){     
-            $tracker_time .=  "$minutes " . xl('minutes'); 
           }
-          else
-          {
-            if($minutes > 0){ 
-              $tracker_time .=  "$minutes " . xl('minute');
-            }            
-          }          
-        }        
-        $tracker_time_calc = $tracker_time_calc - ($minutes * 60);  
-    }
-      if ($allow_sec) {   
-       if ($tracker_time_calc > 0) {
-        if(strlen($minutes != 0)) {
-          if($tracker_time_calc >= 2){   
-            $tracker_time .= ", $tracker_time_calc " . xl('seconds'); 
-          }
-          else
-          {
-            $tracker_time .= ", $tracker_time_calc " . xl('second');               
-          }    
          }
         else
         {
-          if($tracker_time_calc >= 2){ 
-            $tracker_time .= "$tracker_time_calc " . xl('seconds'); 
+          if($minutes >= 2){
+            $tracker_time .=  "$minutes " . xl('minutes');
           }
           else
           {
-            $tracker_time .= "$tracker_time_calc " . xl('second');    
+            if($minutes > 0){
+              $tracker_time .=  "$minutes " . xl('minute');
+            }
           }
-        }        
+        }
+        $tracker_time_calc = $tracker_time_calc - ($minutes * 60);
+    }
+      if ($allow_sec) {
+       if ($tracker_time_calc > 0) {
+        if(strlen($minutes != 0)) {
+          if($tracker_time_calc >= 2){
+            $tracker_time .= ", $tracker_time_calc " . xl('seconds');
+          }
+          else
+          {
+            $tracker_time .= ", $tracker_time_calc " . xl('second');
+          }
+         }
+        else
+        {
+          if($tracker_time_calc >= 2){
+            $tracker_time .= "$tracker_time_calc " . xl('seconds');
+          }
+          else
+          {
+            $tracker_time .= "$tracker_time_calc " . xl('second');
+          }
+        }
       }
-}  
+}
     return $tracker_time ;
-} 
+}
 
 function fetch_Patient_Tracker_Events($from_date, $to_date, $provider_id = null, $facility_id = null, $form_apptstatus = null, $form_apptcat =null)
 {
@@ -149,7 +149,7 @@ function fetch_Patient_Tracker_Events($from_date, $to_date, $provider_id = null,
 
 #check to see if a status code exist as a check in
 function  is_checkin($option) {
-  
+
   $row = sqlQuery("SELECT toggle_setting_1 FROM list_options WHERE " .
     "list_id = 'apptstat' AND option_id = ?", array($option));
   if (empty($row['toggle_setting_1'])) return(false);
@@ -158,7 +158,7 @@ function  is_checkin($option) {
 
 #check to see if a status code exist as a check out
 function  is_checkout($option) {
-  
+
   $row = sqlQuery("SELECT toggle_setting_2 FROM list_options WHERE " .
     "list_id = 'apptstat' AND option_id = ?", array($option));
   if (empty($row['toggle_setting_2'])) return(false);
@@ -189,7 +189,7 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
 
   $datetime = date("Y-m-d H:i:s");
   if (is_null($room)) {
-      $room = '';   
+      $room = '';
   }
   #Check to see if there is an entry in the patient_tracker table.
   $tracker = sqlQuery("SELECT id, apptdate, appttime, eid, pid, original_user, encounter, lastseq,".
@@ -233,7 +233,7 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
     if (!empty($enc_id)) {
       #enc_id (encounter number) is not blank, so update this in tracker.
       sqlStatement("UPDATE `patient_tracker` SET `encounter` = ? WHERE `id` = ?", array($enc_id,$tracker_id));
-    }  
+    }
   }
 
   #Ensure the entry in calendar appt entry has been updated.
@@ -246,7 +246,7 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
   }
   if( $GLOBALS['drug_screen'] && !empty($status)  && is_checkin($status)) {
     $yearly_limit = $GLOBALS['maximum_drug_test_yearly'];
-    $percentage = $GLOBALS['drug_testing_percentage'];	  
+    $percentage = $GLOBALS['drug_testing_percentage'];
     random_drug_test($tracker_id,$percentage,$yearly_limit);
   }
   # Returning the tracker id that has been managed
@@ -265,8 +265,8 @@ function collectApptStatusSettings($option) {
 }
 
 # This is used to collect the tracker elements for the Patient Flow Board Report
-# returns the elements in an array 
-function collect_Tracker_Elements($trackerid) 
+# returns the elements in an array
+function collect_Tracker_Elements($trackerid)
 {
  $res = sqlStatement("SELECT * FROM patient_tracker_element WHERE pt_tracker_id = ? ORDER BY LENGTH(seq), seq ", array($trackerid));
  for($iter=0; $row=sqlFetchArray($res); $iter++) {
@@ -275,7 +275,7 @@ function collect_Tracker_Elements($trackerid)
 return $returnval;
 }
 
-#used to determine check in time 
+#used to determine check in time
 function collect_checkin($trackerid) {
   $tracker = sqlQuery("SELECT patient_tracker_element.start_datetime " .
                                    "FROM patient_tracker_element " .
@@ -341,11 +341,11 @@ function random_drug_test($tracker_id,$percentage,$yearly_limit) {
          $drugtest = 1;
        }
 
-    }   
-   #Update the tracker file.    
+    }
+   #Update the tracker file.
    sqlStatement("UPDATE patient_tracker SET " .
                  "random_drug_test = ? " .
-                 "WHERE id =? ", array($drugtest,$tracker_id)); 
+                 "WHERE id =? ", array($drugtest,$tracker_id));
   }
 }
 

--- a/modules/calendar/add_edit_event.php
+++ b/modules/calendar/add_edit_event.php
@@ -649,6 +649,12 @@ if ($_POST['form_action'] == "save") {
 
     }
 
+    //when selected status is "Deleted" and save is clicked in add_edit_event
+    //delete the event from the database and remove it from calendar
+    if ($_POST['form_apptstatus'] == 'Deleted') {
+        sqlStatement("DELETE FROM libreehr_postcalendar_events WHERE pc_eid = ?", array($_GET['eid']) );
+    }
+
     // done with EVENT insert/update statements
 
         DOBandEncounter();
@@ -742,13 +748,13 @@ if ($_POST['form_action'] == "save") {
             }
         }
 
-        #pass status Deleted to tracker when deleting appointment by clicking delete
+        #pass status Deleted to patient_tracker_element when deleting appointment by clicking delete
         if (!empty($_GET['eid'])) {
             $tmph = $_POST['form_hour'] + 0;
             $tmpm = $_POST['form_minute'] + 0;
             if ($_POST['form_ampm'] == '2' && $tmph < 12) $tmph += 12;
             $appttime = "$tmph:$tmpm:00";
-            $event_date = $POST['form_date'];
+            $event_date = $_POST['form_date'];
 
             manage_tracker_status($event_date,$appttime,$_GET['eid'],$_POST['form_pid'],$_SESSION["authUser"],'Deleted',$_POST['form_room']);
         }

--- a/modules/calendar/add_edit_event.php
+++ b/modules/calendar/add_edit_event.php
@@ -741,6 +741,17 @@ if ($_POST['form_action'] == "save") {
                 sqlStatement("DELETE FROM libreehr_postcalendar_events WHERE pc_eid = ?", array($eid) );
             }
         }
+
+        #pass status Deleted to tracker when deleting appointment by clicking delete
+        if (!empty($_GET['eid'])) {
+            $tmph = $_POST['form_hour'] + 0;
+            $tmpm = $_POST['form_minute'] + 0;
+            if ($_POST['form_ampm'] == '2' && $tmph < 12) $tmph += 12;
+            $appttime = "$tmph:$tmpm:00";
+            $event_date = $POST['form_date'];
+
+            manage_tracker_status($event_date,$appttime,$_GET['eid'],$_POST['form_pid'],$_SESSION["authUser"],'Deleted',$_POST['form_room']);
+        }
  }
 
  if ($_POST['form_action'] != "") {

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3068,6 +3068,7 @@ INSERT INTO list_options ( list_id, option_id, title, seq, is_default, notes ) V
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default, notes ) VALUES ('apptstat','^'       ,'^ Pending from Portal'    ,70,0,'ADBBFF|0');
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default, notes ) VALUES ('apptstat','='       ,'= Rescheduled'    ,75,0,'BFBFBF|0');
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default, notes ) VALUES ('apptstat','&'       ,'& Rescheduled < 24h'    ,80,0,'BFBFBF|0');
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default, notes ) VALUES ('apptstat','Deleted' ,'Deleted'    ,85,0,'0F0F0F|0');
 
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('lists'    ,'warehouse','Warehouses',21,0);
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('warehouse','onsite'   ,'On Site'   , 5,0);


### PR DESCRIPTION
Issues which this PR deals with:
1) When user selects "Deleted" status and saves, status is logged but the appointment isn't deleted off calendar.

2) When user clicks on delete in add-edit-event panel, appointment is deleted off calendar but it is not logged in patient-tracker and patient-tracker-element tables.

Status "Deleted" is added in database.sql file. 

@teryhill This first commit attempts on addressing 2nd point. Currently, the issue with it is that "event_date" is passed as NULL upon clicking delete to manage-tracker-status which makes the control flow to go into block at line 204 instead of block at line 218 in patient_tracker and it results in 2 inserts (one in each table) made when clicking delete with one NULL apptdate value coming up in patient-tracker table instead of one update (into patient-tracker) and one insert (into patient-tracker-element). If I pass the date manually, it works by updating lastseq in patient-tracker table in correct id, eid, pid and creating a new record with corresponding id, status "Deleted" and seq updated.