### PR TITLE
Fix calendar schedule facilities

### DIFF
--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -4,7 +4,7 @@
  *
  *  This program is used to edit the users
  *
- * Copyright (C) 2016-2017 
+ * Copyright (C) 2016-2017
  *
  * LICENSE: This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -22,17 +22,17 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
  * @package LibreEHR
- *  
+ *
  * @link http://librehealth.io
  *
  * Please help the overall project by sending changes you make to the author and to the LibreEHR community.
  *
  */
- 
+
 $fake_register_globals=false;
 $sanitize_all_escapes=true;
 
- 
+
 require_once("../globals.php");
 require_once("../../library/acl.inc");
 require_once("$srcdir/sql.inc");
@@ -312,7 +312,7 @@ function submitform() {
     <?php } ?>
     if(flag == 0){
                     document.forms[0].submit();
-                    parent.$.fn.fancybox.close(); 
+                    parent.$.fn.fancybox.close();
     }
 }
 //Getting the list of selected item in ACL
@@ -361,8 +361,8 @@ function authorized_clicked() {
 <input type=hidden name="get_admin_id" value="<?php echo $GLOBALS['Emergency_Login_email']; ?>" >
 <input type=hidden name="admin_id" value="<?php echo $GLOBALS['Emergency_Login_email_id']; ?>" >
 <input type=hidden name="check_acl" value="">
-<?php 
-//Calculating the grace time 
+<?php
+//Calculating the grace time
 $current_date = date("Y-m-d");
 $password_exp=$iter["pwd_expiration_date"];
 if($password_exp != "0000-00-00")
@@ -446,6 +446,7 @@ foreach($result as $iter2) {
 <?php
   $userFacilities = getUserFacilities($_GET['id']);
   $ufid = array();
+  //ufid is an array of id of schedule facilities of selected user
   foreach($userFacilities as $uf)
     $ufid[] = $uf['id'];
   $fres = sqlStatement("select * from facility where service_location != 0 order by name");
@@ -455,6 +456,7 @@ foreach($result as $iter2) {
    <option <?php echo in_array($frow['id'], $ufid) || $frow['id'] == $iter['facility_id'] ? "selected" : null ?>
       value="<?php echo $frow['id'] ?>"><?php echo htmlspecialchars($frow['name']) ?></option>
 <?php
+  //$iter['facility_id'] is id of default facility of selected user
   endwhile;
 }
 ?>
@@ -581,7 +583,7 @@ echo generate_select_list('irnpool', 'irnpool', $iter['irnpool'],
                 <option value="Flow Board|/interface/patient_tracker/patient_tracker.php">Flow Board</option>
       </select>
 
-  
+
   </td>
   </tr>
   <tr>


### PR DESCRIPTION
@teryhill Attempted a fix for schedule facilities, please have a look.

There is a global `$GLOBALS['restrict_user_facility']` in features tab in Admin which when true restricts Facilities in calendar event panel to only selected schedule facilities set up in Edit User for selected(clicked) user(provider) in calendar. If the global is true, and user selects `facility 1` & `facility 2` in Schedule Facilities and `facility 3` in Default Facility in Edit User, then after saving changes, only `facility 1`, `facility 2` & `facility 3` would show up in Facility in calendar event panel for that user(provider). Otherwise, when global is false, all facilities which have non-zero `service_location`, i.e., facilities which have _service location_ checked will show up in calendar for that user. 

Default facility comes in schedule facilities and all schedule facilities are shown as `selected` with grey background. _users_facility_ table stores _id_ (in `facility_id`) of all schedule facilities corresponding to all users (`table_id is user's id`) and is always synchronized with what is shown as selected in Schedule Facilities box in Edit User. `getUserFacilities(user_id)` is used to get _id_ of schedule facilities of a specific user when global is true otherwise id of all facilities having service location checked  when global is false.

So, workflow of Schedule Facilities & Calendar is:
1) Schedule Facilities box displays all facilities having service location checked in white with schedule ones in grey as `selected` in code.
Note: When global is true then only this will happen otherwise all will be in grey.
2) When user selects _some_ more facilities as schedule ones and saves, they are carried by `schedule_facilities[]` to get inserted in table `users_facility`.
3) Reopening Edit User for same user will now show _those_ facilities also in grey by using `getUserFacilities(user_id)` from `users_facility` table to update Schedule Facilities box.
4) In Calendar event panel for that user(provider), only these schedule facilities + default facility will show up in Facility using `getUserFacilities(user_id)` from `users_facility` table when global is true otherwise all facilities having location service checked (not 0) will show up.