### PR TITLE
Calendar Cancellation Reasons sql fix

### DIFF
--- a/sql/2_0_0-to-2_0_1_upgrade.sql
+++ b/sql/2_0_0-to-2_0_1_upgrade.sql
@@ -124,11 +124,11 @@ DROP TABLE IF EXISTS `menu_entries`;
 
 --Appointment Cancellation Reasons
 #IfNotRow2D list_options list_id lists option_id cancellation_reasons
-INSERT INTO list_options ( list_id, option_id, title,activity ) VALUES (‘lists’,’cancellation_reasons’,’Cancellation Reasons’, 1);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’1’,’No reason given’,5,0);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’2’,’Work’,10,0);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’3’,’Sick’,20,0);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’4’,’Weather’,25,0);
+INSERT INTO list_options ( list_id, option_id, title,activity ) VALUES ('lists','cancellation_reasons','Cancellation Reasons', 1);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','1','No reason given',5,0);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','2','Work',10,0);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','3','Sick',20,0);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','4','Weather',25,0);
 #EndIf
 
 #IfMissingColumn patient_tracker_element reason

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -4109,11 +4109,11 @@ INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('ub_admit_type','9','Information Not Available',60,0);
 
 -- Appointment Cancellation Reasons
-INSERT INTO list_options ( list_id, option_id, title,activity ) VALUES (‘lists’,’cancellation_reasons’,’Cancellation Reasons’, 1);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’1’,’No reason given’,5,0);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’2’,’Work’,10,0);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’3’,’Sick’,20,0);
-INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (‘cancellation_reasons’,’4’,’Weather’,25,0);
+INSERT INTO list_options ( list_id, option_id, title,activity ) VALUES ('lists','cancellation_reasons','Cancellation Reasons', 1);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','1','No reason given',5,0);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','2','Work',10,0);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','3','Sick',20,0);
+INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('cancellation_reasons','4','Weather',25,0);
 --
 -- Table structure for table `lists`
 --


### PR DESCRIPTION
Special characters were used instead of normal single quotes in sql files.  passive fail on upgrades.

Noted during testing that the database menu inserts re-run no matter if they were done or no.   I think that was intended behavior though.