### PR TITLE
Adding event description after hyperlink

### DIFF
--- a/modules/calendar/includes/get_provider_events.php
+++ b/modules/calendar/includes/get_provider_events.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /*
  *  get_provider_events.php Gathering the provider events for the Calendar
  *
@@ -25,14 +25,14 @@ $events = array();
 $fetchedEvents = fetchAllEvents($_POST['start'], $_POST['end']);
 
 foreach($fetchedEvents as $event) {
-  
+
   // skip cancelled appointments
   if ($GLOBALS['display_canceled_appointments'] != 1) {
      if ($event['pc_apptstatus'] == "x") { continue; }
   }
   $status = $event['pc_apptstatus'];
   $colorevents = (collectApptStatusSettings($status));
-  
+
   $e = array();
   $e = $event;
   $e['id'] = $event['pc_eid'];
@@ -49,7 +49,7 @@ foreach($fetchedEvents as $event) {
   }else{
   $e['color'] = $event['pc_catcolor'];
   }
-  
+  $e['e_info'] = " (" . $event['pc_title'] . ")";
   if($event["pc_pid"] > 0) {
     $e['picture_url'] = getPatientPictureUrl($event["pc_pid"]);
     $e['description'] = $event['pc_apptstatus'] . " " . $event['lname'] . ", " . $event['fname'] . " (" . $event['pc_title'];
@@ -102,5 +102,5 @@ foreach($events as $eStart) {
 echo json_encode($events);
 exit();
 
-  
+
 ?>

--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -267,10 +267,13 @@ require('includes/session.php');
             //var link = "../../interface/patient_file/summary/demographics.php?set_pid=" + event['pc_pid'];
             let link = '<?php echo $GLOBALS['webroot'] . "/interface/patient_file/summary/demographics.php?set_pid="; ?>' + event['pc_pid'];
             var titleLink = "<a href='#'>" + event['title'] + "</a>";
+            let titleInfo = "<span style='color: #000;'>" + event['e_info'] + "</span>";
             //find all event title div elements
             var patientEventTitle = element.find('.fc-title');
             //remove title text inside them and insert hyperlink
             patientEventTitle.empty().append(titleLink);
+            //add event description text just after hyperlink
+            patientEventTitle.after(titleInfo);
             patientEventTitle.on("click", function(e) {
               //to stop eventClick handler from executing
               //upon clicking text link


### PR DESCRIPTION
Added event description text after hyperlink name in a Calendar event slot. With this, only clicking on hyperlink would open demographics tab and clicking on anywhere else would open event panel. @teryhill Please have a look.