### PR TITLE
Set Calendar time zone 

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -356,7 +356,7 @@ if (!empty($glrow)) {
         $new_theme = 'rtl_' . $temp_css_theme_name;
 
         // Check file existence
-  
+
         if( file_exists( $include_root.'/themes/'.$new_theme ) ) {
             $GLOBALS['css_header'] = $rootdir.'/themes/'.$new_theme;
         } else {
@@ -540,4 +540,14 @@ if ($fake_register_globals) {
 }
 
 include_once __DIR__ . '/../library/pluginsystem/bootstrap.php';
+
+if ($GLOBALS['calendar_timezone'] !== '') {
+  // getting selected option (in globals)
+  $timezone = $GLOBALS['calendar_timezone'];
+  if (strpos($timezone, '!') !== false) {
+    // removing '!' from timezone which is at 0th place
+    $timezone = substr($timezone, strpos($timezone, '!')+1);
+  }
+  ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals
+}
 ?>

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -541,11 +541,11 @@ if ($fake_register_globals) {
 
 include_once __DIR__ . '/../library/pluginsystem/bootstrap.php';
 
-if ($GLOBALS['calendar_timezone'] !== '') {
-  // getting selected option (in globals)
-  $timezone = $GLOBALS['calendar_timezone'];
+if ($GLOBALS['ehr_timezone'] !== '') {
+  // getting selected time zone option (from globals)
+  $timezone = $GLOBALS['ehr_timezone'];
   if (strpos($timezone, '!') !== false) {
-    // removing '!' from timezone which is at 0th place
+    // removing '!' from timezone which is at 0th place in string
     $timezone = substr($timezone, strpos($timezone, '!')+1);
   }
   ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -547,7 +547,7 @@ if ($GLOBALS['ehr_timezone'] !== '') {
   if (strpos($timezone, '!') !== false) {
     // removing '!' from timezone which is at 0th place in string
     // which happens when default option is selected in time zone list in globals
-    $timezone = substr($timezone, strpos($timezone, '!')+1);
+    $timezone = substr($timezone, strpos($timezone, '!') + 1);
   }
   ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals
 }

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -546,6 +546,7 @@ if ($GLOBALS['ehr_timezone'] !== '') {
   $timezone = $GLOBALS['ehr_timezone'];
   if (strpos($timezone, '!') !== false) {
     // removing '!' from timezone which is at 0th place in string
+    // which happens when default option is selected in time zone list in globals
     $timezone = substr($timezone, strpos($timezone, '!')+1);
   }
   ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -780,6 +780,11 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
     }
     if ($_GET['mode'] == "user") {
       echo " </td>\n";
+      if (strpos($globalTitle, '!') !== false) {
+        // removing '!' from $globalTitle which is at 0th place in string
+        // which happens in case of time zone global when default - php.ini is selected
+        $globalTitle = substr($globalTitle, strpos($globalTitle, '!') + 1);
+      }
       echo "<td align='center' style='color:red;'>" . attr($globalTitle) . "</td>\n";
       echo "<td>&nbsp</td>";
       echo "<td align='center'><input type='checkbox' class='checkbox' value='YES' name='toggle_" . $i . "' id='toggle_" . $i . "' " . attr($settingDefault) . "/></td>\n";

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -603,8 +603,8 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
       if ($_GET['mode'] == "user") {
         $globalTitle = $globalValue;
       }
-      // timezone_identifiers_list() eturns an array containing all defined time zone identifiers
-      // for eg: Asia/Kolkata | Asia/Singapore
+      // timezone_identifiers_list() returns an array containing all defined time zone identifiers
+      // for eg: Asia/Kolkata or Asia/Singapore
       $zone_list = timezone_identifiers_list();
 
       // generating an option list of defined time zones including default time zone from php.ini
@@ -616,16 +616,6 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
         echo "   <option value='" . ($item) . "'";
         if ($title == $fldvalue) echo " selected";
         echo ">";
-        if (strpos($item, '/') !== false) {
-          // if item contains '/', show only what's after '/', for eg:
-          // Asia/Kolkata becomes Kolkata in time zone options list display
-          $item = substr($item, strpos($item, '/')+1);
-        }
-        if (strpos($item, '/') !== false) {
-          // some items contain two '/', for eg:
-          // America/Indiana/Indianapolis
-          $item = substr($item, strpos($item, '/')+1);
-        }
         echo xlt($item);
         echo "</option>\n";
       }

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -599,6 +599,39 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
       echo "  </select>\n";
     }
 
+    else if ($fldtype == 'timezone') {
+      if ($_GET['mode'] == "user") {
+        $globalTitle = $globalValue;
+      }
+      // timezone_identifiers_list() eturns an array containing all defined time zone identifiers
+      // for eg: Asia/Kolkata | Asia/Singapore
+      $zone_list = timezone_identifiers_list();
+
+      // generating an option list of defined time zones including default time zone from php.ini
+      echo "  <select class='form-control input-sm' name='form_$i' id='form_$i'>\n";
+      $top_choice = $flddef;     // default option
+      echo "    <option value='" . ($top_choice) . "'>" . text("Default - php.ini value") . "</option>\n";
+      foreach ($zone_list as $item) {
+        $title = $item;
+        echo "   <option value='" . ($item) . "'";
+        if ($title == $fldvalue) echo " selected";
+        echo ">";
+        if (strpos($item, '/') !== false) {
+          // if item contains '/', show only what's after '/', for eg:
+          // Asia/Kolkata becomes Kolkata in time zone options list display
+          $item = substr($item, strpos($item, '/')+1);
+        }
+        if (strpos($item, '/') !== false) {
+          // some items contain two '/', for eg:
+          // America/Indiana/Indianapolis
+          $item = substr($item, strpos($item, '/')+1);
+        }
+        echo xlt($item);
+        echo "</option>\n";
+      }
+      echo "  </select>\n";
+    }
+
     else if ($fldtype == 'list') {
       if ($_GET['mode'] == "user") {
         $globalTitle = $globalValue;

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -129,6 +129,7 @@ $USER_SPECIFIC_GLOBALS = array('default_tab_1',
                                'print_next_appointment_on_ledger',
                                'calendar_view_type',
                                'calendar_refresh_freq',
+                               'calendar_timezone',
                                'check_appt_time',
                                'event_color',
                                'pat_trkr_timer',
@@ -1523,7 +1524,7 @@ $GLOBALS_METADATA = array(
        'bool',                          // data type
        '1',                             // default
       xl('Use the Appointment Status Colors in the Calendar Instead of the Appointment Category Colors.')
-    ),    
+    ),
 
     'calendar_refresh_freq' => array(
       xl('Calendar Refresh Frequency'),
@@ -1535,6 +1536,19 @@ $GLOBALS_METADATA = array(
       ),
        '360000',                     // default
       xl('How often the calendar automatically refetches events.')
+    ),
+
+    'calendar_timezone' => array(
+      xl('Calendar Time Zone'),
+      array(
+        date_default_timezone_get() => xl('Default - php.ini value'),
+        'Asia/Dubai' => xl('Dubai'),
+        'Asia/Kolkata' => xl('Kolkata'),
+        'Asia/Karachi' => xl('Karachi'),
+        'Asia/Pyongyang' => xl('Pyongyang'),
+      ),
+       date_default_timezone_get(),    // defaults to php.ini "date.timezone" value if set valid otherwise UTC
+      xl('Set calendar time zone.')
     ),
 
     'calendar_provider_view_type' => array(

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -83,6 +83,28 @@ if (stristr(PHP_OS, 'WIN')) {
   $backup_log_dir      = '/tmp';
 }
 
+//------------------------------------
+// for creating $zone_opt_arr at line 1565
+
+// concatenating '!' to avoid Default option from not coming in list
+// when php.ini value is same as an item on zone_list
+$zone_opt_arr = array( '!' . date_default_timezone_get() => xl('Default - php.ini value') );
+
+// iterating to get time zones in form of, for eg:
+// 'Asia/Kolkata' => xl('Kolkata'),
+$zone_list = timezone_identifiers_list();
+foreach ($zone_list as $item) {
+  if (strpos($item, '/') !== false) {
+    $sub_item = substr($item, strpos($item, '/')+1);
+    $zone_opt_arr = array_merge($zone_opt_arr, array( $item => xl($sub_item) ));
+  } else {
+    // only UTC doesn't contain any '/'
+    // and is last item in list
+    $zone_opt_arr = array_merge($zone_opt_arr, array( $item => xl($item) ));
+  }
+}
+//------------------------------------
+
 // REQUIRED FOR TRANSLATION ENGINE.  DO NOT REMOVE
 // Language constant declarations:
 // xl('Appearance')
@@ -1540,14 +1562,8 @@ $GLOBALS_METADATA = array(
 
     'calendar_timezone' => array(
       xl('Calendar Time Zone'),
-      array(
-        date_default_timezone_get() => xl('Default - php.ini value'),
-        'Asia/Dubai' => xl('Dubai'),
-        'Asia/Kolkata' => xl('Kolkata'),
-        'Asia/Karachi' => xl('Karachi'),
-        'Asia/Pyongyang' => xl('Pyongyang'),
-      ),
-       date_default_timezone_get(),    // defaults to php.ini "date.timezone" value if set valid otherwise UTC
+      $zone_opt_arr,  // variable calculated at line 87
+       '!' . date_default_timezone_get(),    // defaults to php.ini "date.timezone" value if set valid otherwise UTC
       xl('Set calendar time zone.')
     ),
 

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -83,28 +83,6 @@ if (stristr(PHP_OS, 'WIN')) {
   $backup_log_dir      = '/tmp';
 }
 
-//------------------------------------
-// for creating $zone_opt_arr at line 1565
-
-// concatenating '!' to avoid Default option from not coming in list
-// when php.ini value is same as an item on zone_list
-$zone_opt_arr = array( '!' . date_default_timezone_get() => xl('Default - php.ini value') );
-
-// iterating to get time zones in form of, for eg:
-// 'Asia/Kolkata' => xl('Kolkata'),
-$zone_list = timezone_identifiers_list();
-foreach ($zone_list as $item) {
-  if (strpos($item, '/') !== false) {
-    $sub_item = substr($item, strpos($item, '/')+1);
-    $zone_opt_arr = array_merge($zone_opt_arr, array( $item => xl($sub_item) ));
-  } else {
-    // only UTC doesn't contain any '/'
-    // and is last item in list
-    $zone_opt_arr = array_merge($zone_opt_arr, array( $item => xl($item) ));
-  }
-}
-//------------------------------------
-
 // REQUIRED FOR TRANSLATION ENGINE.  DO NOT REMOVE
 // Language constant declarations:
 // xl('Appearance')
@@ -151,7 +129,7 @@ $USER_SPECIFIC_GLOBALS = array('default_tab_1',
                                'print_next_appointment_on_ledger',
                                'calendar_view_type',
                                'calendar_refresh_freq',
-                               'calendar_timezone',
+                               'ehr_timezone',
                                'check_appt_time',
                                'event_color',
                                'pat_trkr_timer',
@@ -1558,13 +1536,6 @@ $GLOBALS_METADATA = array(
       ),
        '360000',                     // default
       xl('How often the calendar automatically refetches events.')
-    ),
-
-    'calendar_timezone' => array(
-      xl('Calendar Time Zone'),
-      $zone_opt_arr,  // variable calculated at line 87
-       '!' . date_default_timezone_get(),    // defaults to php.ini "date.timezone" value if set valid otherwise UTC
-      xl('Set calendar time zone.')
     ),
 
     'calendar_provider_view_type' => array(
@@ -3091,6 +3062,15 @@ $GLOBALS_METADATA = array(
     // System Tab
     //
     'System' => array(
+
+    'ehr_timezone' => array(
+      xl('EHR Time Zone'),
+       'timezone',          // data type
+       '!' . date_default_timezone_get(),    // defaults to php.ini "date.timezone" value if set valid otherwise UTC
+       // concatenated '!' to avoid Default option from not coming in list
+       // when php.ini value is same as an item on zone_list
+      xl('Set EHR time zone.')
+    ),
 
     'mysql_bin_dir' => array(
       xl('Path to MySQL Binaries'),

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -111,7 +111,8 @@ $USER_SPECIFIC_TABS = array('Appearance',
                             'Claim',
                             'Demographic',
                             'Calendar',
-                            'Connectors');
+                            'Connectors',
+                            'System');
 $USER_SPECIFIC_GLOBALS = array('default_tab_1',
                                'default_tab_2',
                                'css_header',

--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -188,7 +188,12 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
   }
 
   if ($GLOBALS['calendar_timezone'] !== '') {
+    // getting selected option (in globals)
     $timezone = $GLOBALS['calendar_timezone'];
+    if (strpos($timezone, '!') !== false) {
+      // removing '!' from timezone which is at 0th place
+      $timezone = substr($timezone, strpos($timezone, '!')+1);
+    }
     ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals
   }
 

--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -19,7 +19,6 @@
 *
 */
 require_once(dirname(__FILE__) . '/appointments.inc.php');
-require_once("../interface/globals.php");
 
 function get_Tracker_Time_Interval ($tracker_from_time, $tracker_to_time, $allow_sec=false) {
 

--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -187,6 +187,11 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
     return false;
   }
 
+  if ($GLOBALS['calendar_timezone'] !== '') {
+    $timezone = $GLOBALS['calendar_timezone'];
+    ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals
+  }
+
   $datetime = date("Y-m-d H:i:s");
   if (is_null($room)) {
       $room = '';

--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -19,6 +19,7 @@
 *
 */
 require_once(dirname(__FILE__) . '/appointments.inc.php');
+require_once("../interface/globals.php");
 
 function get_Tracker_Time_Interval ($tracker_from_time, $tracker_to_time, $allow_sec=false) {
 
@@ -185,16 +186,6 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
   $pc_appt =  sqlQuery("SELECT `pc_recurrtype` FROM `libreehr_postcalendar_events` WHERE `pc_eid` = ?", array($eid));
   if ($pc_appt['pc_recurrtype'] != 0) {
     return false;
-  }
-
-  if ($GLOBALS['calendar_timezone'] !== '') {
-    // getting selected option (in globals)
-    $timezone = $GLOBALS['calendar_timezone'];
-    if (strpos($timezone, '!') !== false) {
-      // removing '!' from timezone which is at 0th place
-      $timezone = substr($timezone, strpos($timezone, '!')+1);
-    }
-    ini_set('date.timezone', $timezone);  // sets timezone for function date() according to globals
   }
 
   $datetime = date("Y-m-d H:i:s");


### PR DESCRIPTION
This PR adds a global `calendar_timezone` which the user could use to select his/her time zone for Calendar date/time functions. [date_default_timezone_get](http://php.net/manual/en/function.date-default-timezone-get.php) (used as default time zone for Calendar) gets the value of `date.timezone` in php.ini file if it is valid/supported (valid time zones given [here](http://php.net/manual/en/timezones.php)) otherwise defaults to UTC. The user selected time zone from Main globals or User specific globals (given more preference when different values) is set as `date.timezone` configuration option value using [ini_set](http://php.net/manual/en/function.ini-set.php). 

`date` function is used to fill entries in `date` & `start_datetime` columns in patient_tracker and patient_tracker_element tables respectively. @teryhill Yet to add other time zones ([list here](http://php.net/manual/en/timezones.php)). Should I add all of which are given there? Or go for a particular set covering major regions in time zones?