### PR TITLE
Managing vacation/holidays in bulk

### DIFF
--- a/library/appointments.inc.php
+++ b/library/appointments.inc.php
@@ -114,7 +114,7 @@ function fetchEvents( $from_date, $to_date, $where_param = null, $orderby_param 
     }
 
     $query = "SELECT " .
-    "e.pc_eventDate, e.pc_endDate, e.pc_startTime, e.pc_endTime, e.pc_duration, e.pc_recurrtype, e.pc_recurrspec, e.pc_recurrfreq, e.pc_catid, e.pc_eid, " .
+    "e.pc_facility, e.pc_eventDate, e.pc_endDate, e.pc_startTime, e.pc_endTime, e.pc_duration, e.pc_recurrtype, e.pc_recurrspec, e.pc_recurrfreq, e.pc_catid, e.pc_eid, " .
     "e.pc_title, e.pc_hometext, e.pc_apptstatus, e.pc_location, e.pc_aid, e.pc_eid, e.pc_alldayevent, e.pc_pid, " .
     "p.fname, p.mname, p.lname, p.pid, p.phone_home, p.phone_cell, " .
     "u.fname AS ufname, u.mname AS umname, u.lname AS ulname, u.id AS uprovider_id, " .

--- a/modules/calendar/add.php
+++ b/modules/calendar/add.php
@@ -20,7 +20,7 @@ if ($_POST['form_action'] == "vacation_submit") {
   $end_date = $_POST['endDate'];
   $fetchedEvents = fetchAllEvents($start_date, $end_date); // returns an array of events b/w start and end dates
   if (!empty($fetchedEvents)) {
-    // don't make requested event slots
+    // don't make requested event slots,
     // alert user and close "Add Vacation/Holiday" dialog box
     $alert_close_box = '<script type="text/javascript">
                           alert("There are already some events b/w requested start and end dates. Please try again.");
@@ -91,16 +91,16 @@ if ($_POST['form_action'] == "vacation_submit") {
 
 // 2. Clinic Holiday dates
 if ($_POST['form_action'] == "holiday_submit") {
-  // check if there is an appt. (either recurring or non-recurring) on any of selected holiday dates
+  // check if there is an appt. (either recurring or non-recurring) on at least one of selected holiday dates
   $dateAndType = json_decode($_POST['jsonData'], true);  // convert JSON string to an associative array
   foreach ($dateAndType as $date => $type) {
     // check each selected date
     $fetchedEvents = fetchAllEvents($date, $date); // returns an array of events on $date or including $date (in case of recurring appts.)
     if (!empty($fetchedEvents)) {
-      // don't make requested event slots if there's at least 1 conflicting date
+      // don't make requested event slots,
       // alert user and close "Add Vacation/Holiday" dialog box
       $alert_close_box = '<script type="text/javascript">
-                            alert("There are already some events b/w requested start and end dates. Please try again.");
+                            alert("There are already some events on at least one of the selected dates. Please try again.");
                             var addDialogBox = top.$(".dialogIframe"); // select dialog box element
                             var windowCloseBtn = addDialogBox.find(".closeDlgIframe"); // find close button element
                             windowCloseBtn.trigger("click"); // simulate "click" event on button

--- a/modules/calendar/add.php
+++ b/modules/calendar/add.php
@@ -18,7 +18,7 @@ if ($_POST['form_action'] == "vacation_submit") {
   // check if there is an appt. (either recurring or non-recurring) b/w (or on) start & end dates of vacation
   $start_date = $_POST['startDate'];
   $end_date = $_POST['endDate'];
-  $fetchedEvents = fetchAllEvents($start_date, $end_date); // returns an array of events b/w start and end dates
+  $fetchedEvents = fetchAllEvents($start_date, $end_date, $_POST['provider_id']); // returns an array of events b/w start and end dates for selected provider
   if (!empty($fetchedEvents)) {
     // don't make requested event slots,
     // alert user and close "Add Vacation/Holiday" dialog box
@@ -97,16 +97,23 @@ if ($_POST['form_action'] == "holiday_submit") {
     // check each selected date
     $fetchedEvents = fetchAllEvents($date, $date); // returns an array of events on $date or including $date (in case of recurring appts.)
     if (!empty($fetchedEvents)) {
-      // don't make requested event slots,
-      // alert user and close "Add Vacation/Holiday" dialog box
-      $alert_close_box = '<script type="text/javascript">
-                            alert("There are already some events on at least one of the selected dates. Please try again.");
-                            var addDialogBox = top.$(".dialogIframe"); // select dialog box element
-                            var windowCloseBtn = addDialogBox.find(".closeDlgIframe"); // find close button element
-                            windowCloseBtn.trigger("click"); // simulate "click" event on button
-                          </script>';
-      echo $alert_close_box;
-      exit();
+      foreach ($fetchedEvents as $event) {
+        // check if event is a patient event
+        if (event['pc_pid'] > 0) {
+          // don't make requested event slots,
+          // alert user and close "Add Vacation/Holiday" dialog box
+          $alert_close_box = '<script type="text/javascript">
+                                alert("There are already some patient events on at least one of the selected dates. Please try again.");
+                                var addDialogBox = top.$(".dialogIframe"); // select dialog box element
+                                var windowCloseBtn = addDialogBox.find(".closeDlgIframe"); // find close button element
+                                windowCloseBtn.trigger("click"); // simulate "click" event on button
+                              </script>';
+          echo $alert_close_box;
+          exit();
+        } else {
+          // event is provider event, move onto next event
+        }
+      }
     }
   }
 

--- a/modules/calendar/add.php
+++ b/modules/calendar/add.php
@@ -115,7 +115,8 @@ if ($_POST['form_action'] == "holiday_submit") {
     foreach ($dateAndType as $date => $value) {
       // for each set of date and facility, delete holiday event under all providers
       // no need to iterate through providers in this case
-      sqlStatement("DELETE FROM libreehr_postcalendar_events WHERE pc_eventDate = ? AND pc_facility = ?", array($date, $value[1]));
+      // pc_catid = 6 for holiday event
+      sqlStatement("DELETE FROM libreehr_postcalendar_events WHERE pc_catid = ? AND pc_eventDate = ? AND pc_facility = ?", array("6", $date, $value[1]));
     }
   } elseif ($_POST['holiday_action'] == "Add Holiday") {
     // user requests to add a set of holidays
@@ -246,8 +247,8 @@ if ($_POST['form_action'] == "vacation_submit" || $_POST['form_action'] == "holi
 
     <!--Vacation & Holiday tab options-->
     <div class="row title">
-      <h3><button type="button" class="btn btn-default btn-sm col-sm-offset-1 col-sm-4" id="vacation-btn">Provider Vacation</button></h3>
-      <h3><button type="button" class="btn btn-default btn-sm col-sm-offset-1 col-sm-4" id="holiday-btn">Clinic Holiday</button></h3>
+      <h3><button type="button" class="btn btn-default btn-sm col-sm-offset-1 col-sm-4" id="vacation-btn"><?php echo xlt('Provider Vacation'); ?></button></h3>
+      <h3><button type="button" class="btn btn-default btn-sm col-sm-offset-1 col-sm-4" id="holiday-btn"><?php echo xlt('Clinic Holiday'); ?></button></h3>
     </div>
 
 
@@ -255,20 +256,20 @@ if ($_POST['form_action'] == "vacation_submit" || $_POST['form_action'] == "holi
     <!--Add Vacation tab-->
     <form class="form-horizontal vacation-form" id="provider_form" action="add.php" method="POST" style="margin-top: 20px;">
       <div class="form-group">
-        <label class="control-label col-sm-2" for="startDate">Start date</label>
+        <label class="control-label col-sm-2" for="startDate"><?php echo xlt('Start date'); ?></label>
         <div class="col-sm-4">
           <input type="text" class="form-control" id="startDate" name="startDate" placeholder="Date">
         </div>
-        <label class="control-label col-sm-2" for="endDate">End date</label>
+        <label class="control-label col-sm-2" for="endDate"><?php echo xlt('End date'); ?></label>
         <div class="col-sm-4">
           <input type="text" class="form-control" id="endDate" name="endDate" placeholder="Date">
         </div>
       </div>
       <div class="form-group">
-        <label class="control-label col-sm-2" for="provider_id">Provider</label>
+        <label class="control-label col-sm-2" for="provider_id"><?php echo xlt('Provider'); ?></label>
         <div class="col-sm-10">
           <select class="form-control" id="provider_id" name="provider_id">
-            <option value="0">Choose Provider</option>
+            <option value="0"><?php echo xlt('Choose Provider'); ?></option>
             <?php
             $providers = getProviderInfo();
             foreach($providers as $provider) {
@@ -283,7 +284,7 @@ if ($_POST['form_action'] == "vacation_submit" || $_POST['form_action'] == "holi
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
           <input type="hidden" name="form_action" value="vacation_submit">
-          <button type="submit" class="btn btn-default" id="vacation_submit">Submit</button>
+          <button type="submit" class="btn btn-default" id="vacation_submit"><?php echo xlt('Submit'); ?></button>
         </div>
       </div>
     </form>
@@ -293,7 +294,7 @@ if ($_POST['form_action'] == "vacation_submit" || $_POST['form_action'] == "holi
     <!--Add Holiday tab-->
     <form class="form-horizontal holiday-form" id="clinic_form" action="add.php" method="POST" style="margin-top: 20px;">
       <div class="form-group">
-        <label class="control-label col-sm-2" for="addDate">Date</label>
+        <label class="control-label col-sm-2" for="addDate"><?php echo xlt('Date'); ?></label>
         <div class="col-sm-4">
           <input type="text" class="form-control" id="addDate" name="addDate" placeholder="Date">
         </div>
@@ -301,18 +302,18 @@ if ($_POST['form_action'] == "vacation_submit" || $_POST['form_action'] == "holi
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-4">
           <input type="radio" id="radio-choice-1" name="holiday-actions" value="Add Holiday" class="holiday-action">
-          <label for="radio-choice-1">Add Holiday(s)</label>
+          <label for="radio-choice-1"><?php echo xlt('Add Holiday(s)'); ?></label>
         </div>
         <div class="col-sm-4">
           <input type="radio" id="radio-choice-2" name="holiday-actions" value="Delete Holiday" class="holiday-action">
-          <label for="radio-choice-2">Delete Holiday(s)</label>
+          <label for="radio-choice-2"><?php echo xlt('Delete Holiday(s)'); ?></label>
         </div>
       </div>
       <div class="form-group">
-        <label class="control-label col-sm-2" for="clinic_id">Clinic</label>
+        <label class="control-label col-sm-2" for="clinic_id"><?php echo xlt('Clinic'); ?></label>
         <div class="col-sm-10">
           <select class="form-control" id="clinic_id" name="clinic_id">
-            <option value="0" data-text="Undefined">Choose Clinic/Facility</option>
+            <option value="0" data-text="Undefined"><?php echo xlt('Choose Clinic/Facility'); ?></option>
             <?php
               $pref_facility = sqlFetchArray(sqlStatement( "SELECT u.facility_id
                                                             FROM users u
@@ -353,26 +354,26 @@ if ($_POST['form_action'] == "vacation_submit" || $_POST['form_action'] == "holi
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-2">
           <input type="radio" id="radio-choice-3" name="holiday-types" value="Full day" class="holiday-type">
-          <label for="radio-choice-3">Full day</label>
+          <label for="radio-choice-3"><?php echo xlt('Full day'); ?></label>
         </div>
         <div class="col-sm-2">
           <input type="radio" id="radio-choice-4" name="holiday-types" value="First half" class="holiday-type">
-          <label for="radio-choice-4">First Half</label>
+          <label for="radio-choice-4"><?php echo xlt('First Half'); ?></label>
         </div>
         <div class="col-sm-2">
           <input type="radio" id="radio-choice-5" name="holiday-types" value="Second half" class="holiday-type">
-          <label for="radio-choice-5">Second Half</label>
+          <label for="radio-choice-5"><?php echo xlt('Second Half'); ?></label>
         </div>
       </div>
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-2">
-          <button type="button" class="btn btn-default" id="add">Add</button>
+          <button type="button" class="btn btn-default" id="add"><?php echo xlt('Add'); ?></button>
         </div>
         <div class="col-sm-2">
           <input type="hidden" name="form_action" value="holiday_submit">
           <!-- To distinguish b/w two types of holiday action while submitting: Add and Delete -->
           <input type="hidden" name="holiday_action" id="actionValue" value="">
-          <button type="submit" class="btn btn-default" id="holiday_submit">Submit</button>
+          <button type="submit" class="btn btn-default" id="holiday_submit"><?php echo xlt('Submit'); ?></button>
           <!-- For passing datesAndTypes object to server via JSON -->
           <input type="hidden" name="jsonData" id="jsonValue" value="">
         </div>

--- a/modules/calendar/add.php
+++ b/modules/calendar/add.php
@@ -1,0 +1,170 @@
+<?php
+require_once("../../interface/globals.php");
+require_once("$srcdir/headers.inc.php");
+require_once("$srcdir/htmlspecialchars.inc.php");
+require_once("$srcdir/patient.inc");
+require_once("$srcdir/formatting.inc.php");
+
+$dateFormat = DateFormatRead();
+$providers = getProviderInfo();
+call_required_libraries(array("jquery-min-3-1-1","bootstrap","datepicker"));
+?>
+<html>
+<head>
+  <link href="css/add.css" rel="stylesheet" />
+  <script type="text/javascript" src="../../library/dialog.js"></script>
+</head>
+<body>
+
+  <div class="container-fluid">
+    <div class="row title">
+      <h3><?php echo htmlspecialchars(xl('Add Vacation/Holiday'), ENT_NOQUOTES); ?></h3>
+    </div>
+
+    <!--Vacation & Holiday tab options-->
+    <div class="row title">
+      <h3><button type="button" class="btn btn-default btn-sm col-sm-offset-1 col-sm-4" id="vacation-btn">Add Vacation</button></h3>
+      <h3><button type="button" class="btn btn-default btn-sm col-sm-offset-1 col-sm-4" id="holiday-btn">Add Holiday</button></h3>
+    </div>
+
+
+    <!--Vacation & Holiday tabs-->
+    <!--Add Vacation tab-->
+    <form class="form-horizontal vacation-form"  action="" method="POST" style="margin-top: 20px;">
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="startDate">Start date</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control" id="startDate" name="startDate" placeholder="Date" required>
+        </div>
+        <label class="control-label col-sm-2" for="endDate">End date</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control" id="endDate" name="endDate" placeholder="Date" required>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="provider_id">Provider</label>
+        <div class="col-sm-10">
+          <select class="form-control" id="provider_id" name="provider_id">
+            <option value="0">Choose Provider</option>
+            <?php
+            foreach($providers as $provider) {
+              $id = $provider['id'];
+              $selected = ($_POST['provider_id'] == $id) ? "selected" : "";
+              echo "<option value='$id' $selected>" . htmlspecialchars($provider['lname'],ENT_QUOTES) . ", " . htmlspecialchars($provider['fname'],ENT_QUOTES) . "</option>\n";
+            }
+            ?>
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+          <button type="submit" class="btn btn-default" name="submit" value="1">Submit</button>
+        </div>
+      </div>
+    </form>
+    <!--Add Vacation tab-->
+
+
+    <!--Add Holiday tab-->
+    <form class="form-horizontal holiday-form"  action="" method="POST" style="margin-top: 20px;">
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="addDate">Add date</label>
+        <div class="col-sm-4">
+          <input type="text" class="form-control" id="addDate" name="addDate" placeholder="Date" required>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="provider_id">Provider</label>
+        <div class="col-sm-10">
+          <select class="form-control" id="provider_id" name="provider_id">
+            <option value="0">Choose Provider</option>
+            <?php
+            foreach($providers as $provider) {
+              $id = $provider['id'];
+              $selected = ($_POST['provider_id'] == $id) ? "selected" : "";
+              echo "<option value='$id' $selected>" . htmlspecialchars($provider['lname'],ENT_QUOTES) . ", " . htmlspecialchars($provider['fname'],ENT_QUOTES) . "</option>\n";
+            }
+            ?>
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-2">
+          <button type="button" class="btn btn-default" id="add">Add</button>
+        </div>
+        <div class="col-sm-2">
+          <button type="submit" class="btn btn-default" name="submit" value="1">Submit</button>
+        </div>
+      </div>
+    </form>
+    <br>
+    <table class="table table-hover col-sm-offset-1" id="date-table">
+      <tr style="background-color: #ddd;">
+        <th><?php echo xlt('Selected date(s)')?></th>
+      </tr>
+    </table>
+
+    <script type="text/javascript">
+      $(document).ready(function () {
+        // Adding selected date to date-table
+        $("#add").on("click", function () {
+          var dateForm = $("input#addDate").val();
+          var row = '<tr class="date-row">' +
+                        '<td>' + dateForm + '</td>'
+                    '</tr>';
+          $("#date-table").append(row).fadeIn();
+        });
+      });
+    </script>
+    <!--Add Holiday tab-->
+
+
+    <!-- Controlling tabs -->
+    <script type="text/javascript">
+      $(document).ready(function () {
+        $("#holiday-btn").on("click", function () {
+          $(".vacation-form").fadeOut(100, function (){
+            $(".holiday-form").fadeIn(400);
+          });
+        });
+
+        $("#vacation-btn").on("click", function () {
+          $("#date-table").fadeOut(100);
+          $(".date-row").remove();
+          $(".holiday-form").fadeOut(100, function (){
+            $(".vacation-form").fadeIn(400);
+          });
+        });
+      });
+    </script>
+  </div>
+
+  <script>
+    $('#addDate').datetimepicker({
+      timepicker: false,
+      format: '<?php echo $dateFormat; ?>',
+      formatDate: '<?php echo $dateFormat; ?>',
+    });
+    $('#startDate').datetimepicker({
+      timepicker: false,
+      format: '<?php echo $dateFormat; ?>',
+      formatDate: '<?php echo $dateFormat; ?>',
+      onShow: function( ct ){
+        this.setOptions({
+          maxDate: $('#endDate').val() ? $('#endDate').val() : false
+       })
+      }
+    });
+    $('#endDate').datetimepicker({
+      timepicker: false,
+      format: '<?php echo $dateFormat; ?>',
+      formatDate: '<?php echo $dateFormat; ?>',
+      onShow: function( ct ){
+        this.setOptions({
+          minDate: $('#startDate').val() ? $('#startDate').val() : false
+       })
+      }
+    });
+  </script>
+</body>
+</html>

--- a/modules/calendar/add.php
+++ b/modules/calendar/add.php
@@ -129,11 +129,11 @@ if ($_POST['form_action'] == "holiday_submit") {
       if (!empty($fetchedEvents)) {
         foreach ($fetchedEvents as $event) {
           // check if event is a patient event
-          if (event['pc_pid'] > 0) {
+          if ($event['pc_pid'] > 0 && $event['pc_facility'] == $value[1]) {
             // don't make requested event slots,
             // alert user and close "Add Vacation/Holiday" dialog box
             $alert_close_box = '<script type="text/javascript">
-                                  alert("There are already some patient events on at least one of the selected dates. Please try again.");
+                                  alert("There are already some patient events with same facility on at least one of the selected dates. Please try again.");
                                   var addDialogBox = top.$(".dialogIframe"); // select dialog box element
                                   var windowCloseBtn = addDialogBox.find(".closeDlgIframe"); // find close button element
                                   windowCloseBtn.trigger("click"); // simulate "click" event on button
@@ -205,13 +205,14 @@ if ($_POST['form_action'] == "holiday_submit") {
         $args['facility'] = $value[1];
         $args['billing_facility'] = $value[1];
       // Insert events - A holiday event is made for each selected date,
-      // covering Calendar slots according to selected day type for that date with selected facility under all providers.
+      // covering Calendar slots according to selected day type for that date with selected facility under all passed providers.
       InsertEvent($args);
     }
 
     // reached here, means no conflicting dates, make requested events
     foreach ($dateAndType as $date => $value) {
-      $providers = getProviderInfo();
+      // pass only those providers which are specific to selected facility ($value[1]) for $date
+      $providers = getProviderInfo('%', true, $value[1]);
       foreach($providers as $provider) {
         $prov_id = $provider['id'];
         createHolidayEvent($date, $value, $prov_id);

--- a/modules/calendar/css/add.css
+++ b/modules/calendar/css/add.css
@@ -1,0 +1,16 @@
+.btn {
+  color: black!important;
+}
+
+.title {
+  margin-left: 1px;
+}
+
+.holiday-form {
+    display: none;
+}
+
+#date-table {
+    display: none;
+    width: 300px;
+}

--- a/modules/calendar/css/add.css
+++ b/modules/calendar/css/add.css
@@ -12,5 +12,5 @@
 
 #date-table {
     display: none;
-    width: 300px;
+    width: 450px;
 }

--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -138,6 +138,7 @@ require('includes/session.php');
       var title_agenda2 = '<?php echo xlt('2 day'); ?>';
       var title_agenda = '<?php echo xlt('1 day'); ?>';
       var title_search = '<?php echo xlt('search'); ?>';
+      var title_add = '<?php echo xlt('add'); ?>';
       var title_print = '<?php echo xlt('print'); ?>';
       var lang_default = '<?php echo $default_lang_id['lang_code']; ?>';
 
@@ -146,7 +147,7 @@ require('includes/session.php');
         locale: lang_default,
         height: 'parent',
         header: {
-        left: 'prev,next,today print,search',
+        left: 'prev,next,today print,search,add',
         center: 'title',
         right: 'providerAgenda,providerAgenda2Day,providerAgendaWeek,timelineMonth'
         },
@@ -228,6 +229,12 @@ require('includes/session.php');
               text: title_search,
               click: function() {
                 window.location.href = 'search.php';
+              }
+            },
+            add: {
+              text: title_add,
+              click: function () {
+                dlgopen('add.php', '_blank', 775, 375);
               }
             }
         },


### PR DESCRIPTION
This first commit adds the interface for this feature where user can enter holidays, vacations in bulk without going to the dates on the calendar to do it. Calendar now has an _add_ button as shown below:
![add](https://user-images.githubusercontent.com/25399108/41508393-aa5ab190-7261-11e8-9f34-60ba5bcee633.JPG)

Clicking on this button would open a dialog modal having two tab views/forms:

Add Vacation form
![vac](https://user-images.githubusercontent.com/25399108/41508397-cea56c2a-7261-11e8-842a-20585c2089f0.JPG)

Functionality:
In this tab, user can select a range of consecutive dates of vacation for a selected provider from _Start Date_ to _End Date_. Upon submitting this form, vacation slot would be booked for specified dates and specified provider.


Add Holiday form
![holid](https://user-images.githubusercontent.com/25399108/41508399-d95d5cc2-7261-11e8-934c-32082969c581.JPG)

Functionality:
In this tab, user can select and _add_ disjoint dates of holiday (which will be shown under _Selected dates_ column) for a particular clinic/facility. Upon submitting this form, holiday slot would be booked for specified dates and all providers related with that clinic/facility.

@teryhill Please have a look.
