### PR TITLE
sql_upgrade move/hide/menu

### DIFF
--- a/sites/default/menu_data.json
+++ b/sites/default/menu_data.json
@@ -491,6 +491,14 @@
             "requirement" : 0,
             "acl_req" : [ "admin", "users" ]
         }, { 
+            "label" : "Upgrade Database",
+            "menu_id" : "adm0",
+            "target" : "adm",
+            "url" : "/sql/sql_upgrade.php",
+            "children" : [ ],
+            "requirement" : 0,
+            "acl_req" : [ "admin", "super" ]
+        }, { 
             "label" : "Native Data Loads",
             "menu_id" : "adm0",
             "target" : "adm",

--- a/sql/sql_upgrade.php
+++ b/sql/sql_upgrade.php
@@ -42,7 +42,7 @@ ksort($versions);
 <head>
 <title>LibreHealth EHR Database Upgrade</title>
 <link rel='STYLESHEET' href='../interface/themes/style_setup.css'>
-<link rel="shortcut icon" href="../public/images/favicon.ico" />
+<link rel="shortcut icon" href="../favicon.ico" />
 </head>
 <body>
 <center>

--- a/sql/sql_upgrade.php
+++ b/sql/sql_upgrade.php
@@ -14,11 +14,11 @@
 // Disable PHP timeout.  This will not work in safe mode.
 ini_set('max_execution_time', '0');
 
-$ignoreAuth = true; // no login required
+//$ignoreAuth = true; // no login required
 
-require_once('interface/globals.php');
-require_once('library/sql.inc');
-require_once('library/sql_upgrade_fx.php');
+require_once('../interface/globals.php');
+require_once('../library/sql.inc');
+require_once('../library/sql_upgrade_fx.php');
 
 
 // Force logging off
@@ -41,8 +41,8 @@ ksort($versions);
 <html>
 <head>
 <title>LibreHealth EHR Database Upgrade</title>
-<link rel='STYLESHEET' href='interface/themes/style_setup.css'>
-<link rel="shortcut icon" href="favicon.ico" />
+<link rel='STYLESHEET' href='../interface/themes/style_setup.css'>
+<link rel="shortcut icon" href="../public/images/favicon.ico" />
 </head>
 <body>
 <center>
@@ -66,7 +66,7 @@ if (!empty($_POST['form_submit'])) {
   flush();
 
   echo "<font color='green'>Updating global configuration defaults...</font><br />\n";
-  require_once("library/globals.inc.php");
+  require_once("../library/globals.inc.php");
   foreach ($GLOBALS_METADATA as $grpname => $grparr) {
     foreach ($grparr as $fldid => $fldarr) {
       list($fldname, $fldtype, $flddef, $flddesc) = $fldarr;

--- a/sql/sql_upgrade.php
+++ b/sql/sql_upgrade.php
@@ -14,7 +14,6 @@
 // Disable PHP timeout.  This will not work in safe mode.
 ini_set('max_execution_time', '0');
 
-//$ignoreAuth = true; // no login required
 
 require_once('../interface/globals.php');
 require_once('../library/sql.inc');


### PR DESCRIPTION
Hiding sql_upgrade, requiring auth, adding to admin menu, preventing direct access.

This may not be a real security issue, but it certainly makes things easier for the user to upgrade.