### PR TITLE
Update menu patient add/search link

### DIFF
--- a/sites/default/menu_data.json
+++ b/sites/default/menu_data.json
@@ -1,11 +1,11 @@
-[ { 
+[ {
     "label" : "Calendar",
     "menu_id" : "cal0",
     "target" : "cal",
     "url" : "/interface/main/main_info.php",
     "children" : [ ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "Flow Board",
     "menu_id" : "pfb0",
     "target" : "flb",
@@ -13,61 +13,61 @@
     "children" : [ ],
     "requirement" : 0,
     "global_req" : "!disable_pat_trkr"
-}, { 
+}, {
     "label" : "Messages ",
     "menu_id" : "msg0",
     "target" : "pat",
     "url" : "/interface/main/messages/messages.php?form_active=1",
     "children" : [ ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "Patient/Client",
     "menu_id" : "patimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Finder",
         "menu_id" : "fin0",
         "target" : "fin",
         "url" : "/interface/main/finder/dynamic_finder.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Add New/Search",
         "menu_id" : "new0",
         "target" : "pat",
-        "url" : "/interface/new/new.php",
+        "url" : "/interface/new/new_comprehensive.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Recycle bin",
         "menu_id" : "rbin",
         "target" : "rbin0",
         "url" : "/interface/patient_file/recover.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Summary",
         "menu_id" : "dem1",
         "target" : "pat",
         "url" : "/interface/patient_file/summary/demographics.php",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Visits",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Create Visit",
             "menu_id" : "nen1",
             "target" : "enc",
             "url" : "/interface/forms/patient_encounter/new.php?autoloaded=1&calenc=",
             "children" : [ ],
             "requirement" : 1
-        }, { 
+        }, {
             "label" : "Current",
             "menu_id" : "enc2",
             "target" : "enc",
             "url" : "/interface/patient_file/encounter/encounter_top.php",
             "children" : [ ],
             "requirement" : 3
-        }, { 
+        }, {
             "label" : "Visit History",
             "menu_id" : "ens1",
             "target" : "enc",
@@ -76,9 +76,9 @@
             "requirement" : 1
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Records",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Patient Record Request",
             "menu_id" : "prq1",
             "target" : "enc",
@@ -87,20 +87,20 @@
             "requirement" : 1
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Visit Forms",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Import",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Upload",
             "menu_id" : "ccr0",
             "target" : "pat",
             "url" : "/interface/patient_file/ccr_import.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Pending Approval",
             "menu_id" : "apr0",
             "target" : "pat",
@@ -111,31 +111,31 @@
         "requirement" : 0
     } ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "Fees",
     "menu_id" : "feeimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Fee Sheet",
         "menu_id" : "cod2",
         "target" : "enc",
         "url" : "/interface/patient_file/encounter/load_form.php?formname=fee_sheet",
         "children" : [ ],
         "requirement" : 2
-    }, { 
+    }, {
         "label" : "Payment",
         "menu_id" : "pay1",
         "target" : "enc",
         "url" : "/interface/patient_file/front_payment.php",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Checkout",
         "menu_id" : "bil1",
         "target" : "enc",
         "url" : "/interface/patient_file/pos_checkout.php?framed=1",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Billing",
         "menu_id" : "bil0",
         "target" : "pat",
@@ -143,28 +143,28 @@
         "children" : [ ],
         "requirement" : 0,
         "global_req" : "!simplified_demographics"
-    }, { 
+    }, {
         "label" : "Posting",
         "menu_id" : "bil0",
         "target" : "pat",
         "url" : "/interface/billing/sl_eob_search.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Batch Payments",
         "menu_id" : "npa0",
         "target" : "pat",
         "url" : "/interface/billing/new_payment.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Verify Patient Billing Data",
         "menu_id" : "npa0",
         "target" : "pat",
         "url" : "/interface/reports/pre_billing_issues.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "EDI History",
         "menu_id" : "edi0",
         "target" : "pat",
@@ -176,10 +176,10 @@
     } ],
     "requirement" : 0,
     "global_req" : "enable_fees_in_menu"
-}, { 
+}, {
     "label" : "Inventory",
     "menu_id" : "invimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Management",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -187,7 +187,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "drugs" ]
-    }, { 
+    }, {
         "label" : "Destroyed",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -198,66 +198,66 @@
     "requirement" : 0,
     "acl_req" : [ "admin", "drugs" ],
     "global_req" : "inhouse_pharmacy"
-}, { 
+}, {
     "label" : "Procedures",
     "menu_id" : "proimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Providers",
         "menu_id" : "orl0",
         "target" : "pat",
         "url" : "/interface/orders/procedure_provider_list.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Configuration",
         "menu_id" : "ort0",
         "target" : "pat",
         "url" : "/interface/orders/types.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Load Compendium",
         "menu_id" : "orc0",
         "target" : "pat",
         "url" : "/interface/orders/load_compendium.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Pending Review",
         "menu_id" : "orp1",
         "target" : "enc",
         "url" : "/interface/orders/orders_results.php?review=1",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Patient Results",
         "menu_id" : "orr1",
         "target" : "enc",
         "url" : "/interface/orders/orders_results.php",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Lab Overview",
         "menu_id" : "lda1",
         "target" : "enc",
         "url" : "/interface/patient_file/summary/labdata.php",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Batch Results",
         "menu_id" : "orb0",
         "target" : "pat",
         "url" : "/interface/orders/orders_results.php?batch=1",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Electronic Reports",
         "menu_id" : "ore0",
         "target" : "pat",
         "url" : "/interface/orders/list_reports.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Lab Documents",
         "menu_id" : "dld0",
         "target" : "pat",
@@ -266,24 +266,24 @@
         "requirement" : 0
     } ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "New Crop",
     "menu_id" : "feeimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "e-Rx",
         "menu_id" : "ncr0",
         "target" : "pat",
         "url" : "/interface/eRx.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "e-Rx Renewal",
         "menu_id" : "ncr1",
         "target" : "pat",
         "url" : "/interface/eRx.php?page=status",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "e-Rx EPCS",
         "menu_id" : "ncr2",
         "target" : "pat",
@@ -294,10 +294,10 @@
     } ],
     "requirement" : 1,
     "global_req" : [ "erx_enable", "newcrop_user_role" ]
-}, { 
+}, {
     "label" : "Administration",
     "menu_id" : "admimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Globals",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -305,7 +305,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "Edit Menu",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -314,7 +314,7 @@
         "requirement" : 0,
         "global_req" : "!role_based_menu_status",
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "Manage Roles",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -323,7 +323,7 @@
         "requirement" : 0,
         "global_req" : "role_based_menu_status",
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "Facilities",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -331,7 +331,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "users" ]
-    }, { 
+    }, {
         "label" : "Users",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -339,7 +339,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "users" ]
-    }, { 
+    }, {
         "label" : "Addr Book",
         "menu_id" : "adb0",
         "target" : "adm",
@@ -347,7 +347,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "practice" ]
-    }, { 
+    }, {
         "label" : "Practice",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -355,7 +355,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "practice" ]
-    }, { 
+    }, {
         "label" : "Codes",
         "menu_id" : "sup0",
         "target" : "adm",
@@ -363,7 +363,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "superbill" ]
-    }, { 
+    }, {
         "label" : "Layouts",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -371,7 +371,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "Lists",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -379,7 +379,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "ACL",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -387,7 +387,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "acl" ]
-    }, { 
+    }, {
         "label" : "Files",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -395,7 +395,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "Backup",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -403,7 +403,7 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ]
-    }, { 
+    }, {
         "label" : "Rules",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -412,7 +412,7 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "enable_cdr"
-    }, { 
+    }, {
         "label" : "Alerts",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -421,7 +421,7 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "enable_cdr"
-    }, { 
+    }, {
         "label" : "Patient Reminders",
         "menu_id" : "adm0",
         "target" : "adm",
@@ -430,9 +430,9 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "enable_cdr"
-    }, { 
+    }, {
         "label" : "Other",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Language",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -440,7 +440,7 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "language" ]
-        }, { 
+        }, {
             "label" : "Forms",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -448,7 +448,7 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "forms" ]
-        }, { 
+        }, {
             "label" : "Calendar Administration",
             "menu_id" : "adm0",
             "target" : "lst",
@@ -456,7 +456,7 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "calendar" ]
-        }, { 
+        }, {
             "label" : "Logs",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -464,7 +464,7 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "users" ]
-        }, { 
+        }, {
             "label" : "Database",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -473,7 +473,7 @@
             "requirement" : 0,
             "acl_req" : [ "admin", "database" ],
             "global_req" : "!disable_sql_admin_link"
-        }, { 
+        }, {
             "label" : "eRx Logs",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -482,7 +482,7 @@
             "requirement" : 0,
             "acl_req" : [ "admin", "super" ],
             "global_req" : [ "erx_enable", "newcrop_user_role" ]
-        }, { 
+        }, {
             "label" : "Certificates",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -490,7 +490,7 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "users" ]
-        }, { 
+        }, {
             "label" : "Native Data Loads",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -498,7 +498,7 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "super" ]
-        }, { 
+        }, {
             "label" : "External Data Loads",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -506,21 +506,21 @@
             "children" : [ ],
             "requirement" : 0,
             "acl_req" : [ "admin", "super" ]
-        }, { 
+        }, {
             "label" : "Merge Encounters",
             "menu_id" : "adm0",
             "target" : "adm",
             "url" : "/modules/merge_encounters/index.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Merge Patients",
             "menu_id" : "adm0",
             "target" : "adm",
             "url" : "/interface/patient_file/merge_patients.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Audit Log Tamper",
             "menu_id" : "adm0",
             "target" : "adm",
@@ -532,26 +532,26 @@
         "requirement" : 0
     } ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "Reports",
     "menu_id" : "repimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Clients",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Patient List",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/patient_list.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Patient List By Referrer",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/patient_list_by_referrer.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Prescriptions and Dispensations",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -559,21 +559,21 @@
             "children" : [ ],
             "requirement" : 0,
             "global_req" : "!disable_prescriptions"
-        }, { 
+        }, {
             "label" : "Patient List Creation",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/patient_list_creation.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Clinical",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/clinical_reports.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Immunization Registry",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -582,16 +582,16 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Visits",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Appointments",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/appointments_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Patient Flow Board",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -599,56 +599,56 @@
             "children" : [ ],
             "requirement" : 0,
             "global_req" : "!disable_pat_trkr"
-        }, { 
+        }, {
             "label" : "Encounters",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/encounters_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Patient Billing Encounter by Carrier",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/encounters_report_carrier.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Appointments and Encounters",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/appt_encounter_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Superbill",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/custom_report_range.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Eligibility",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/edi_270.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Eligibility Response",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/edi_271.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Claim Status Request",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/edi_276.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Chart Location Activity",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -656,7 +656,7 @@
             "children" : [ ],
             "requirement" : 0,
             "global_req" : "!disable_chart_tracker"
-        }, { 
+        }, {
             "label" : "Charts Checked Out",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -672,14 +672,14 @@
             "children" : [ ],
             "requirement" : 0,
             "global_req" : "!disable_chart_tracker"
-        }, { 
+        }, {
             "label" : "Services by Category",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/services_by_category.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Syndromic Surveillance",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -688,58 +688,58 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Financial",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Sales by Item",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/sales_by_item.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Cash Receipts by Provider",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/billing/sl_receipts_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Front Office Receipts",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/front_receipts_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Receipts Summary",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/receipts_by_method_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Collections",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/collections_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Patient Ledger by Date",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/pat_ledger.php?form=0",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Adjustments",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/adjustments.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Financial Summary by Service Code",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -748,22 +748,22 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Inventory",
         "icon" : "fa-caret-right",
-        "children" : [ { 
+        "children" : [ {
             "label" : "List",
             "url" : "/interface/reports/inventory_list.php",
             "target" : "rep",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Activity",
             "url" : "/interface/reports/inventory_activity.php",
             "target" : "rep",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Transactions",
             "url" : "/interface/reports/inventory_transactions.php",
             "target" : "rep",
@@ -772,15 +772,15 @@
         } ],
         "requirement" : 0,
         "global_req" : "inhouse_pharmacy"
-    }, { 
+    }, {
         "label" : "Procedures",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Pending Orders",
             "url" : "/interface/orders/pending_orders.php",
             "target" : "rep",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Procedure Statistics",
             "url" : "/interface/orders/procedure_stats.php",
             "target" : "rep",
@@ -788,23 +788,23 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Insurance",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Patient Insurance Distribution",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/insurance_allocation_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Indigent Patients",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/billing/indigent_patients_report.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Unique Seen Patients",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -813,21 +813,21 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Blank Forms",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Demographics",
             "url" : "/interface/patient_file/summary/demographics_print.php",
             "target" : "rep",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Superbill/Fee Sheet",
             "url" : "/interface/patient_file/printed_fee_sheet.php",
             "target" : "rep",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Referral",
             "url" : "/interface/patient_file/transaction/print_referral.php",
             "target" : "rep",
@@ -835,16 +835,16 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Services",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Background Services",
             "menu_id" : "rep0",
             "target" : "rep",
             "url" : "/interface/reports/background_services.php",
             "children" : [ ],
             "requirement" : 0
-        }, { 
+        }, {
             "label" : "Direct Message Log",
             "menu_id" : "rep0",
             "target" : "rep",
@@ -855,17 +855,17 @@
         "requirement" : 0
     } ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "Miscellaneous",
     "menu_id" : "misimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Patient Education",
         "menu_id" : "ped0",
         "target" : "msc",
         "url" : "/interface/reports/patient_edu_web_lookup.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Portal Dashboard",
         "menu_id" : "por2",
         "target" : "por",
@@ -874,14 +874,14 @@
         "requirement" : 0,
         "global_req_strict" : "portal_onsite_enable",
         "acl_req" : [ "patientportal", "portal" ]
-    }, { 
+    }, {
         "label" : "Authorizations",
         "menu_id" : "aun0",
         "target" : "msc",
         "url" : "/interface/main/authorizations/authorizations.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Addr Book",
         "menu_id" : "adb0",
         "target" : "msc",
@@ -889,45 +889,45 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "practice" ]
-    }, { 
+    }, {
         "label" : "Order Catalog",
         "menu_id" : "ort0",
         "target" : "msc",
         "url" : "/interface/orders/types.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
- 
+    }, {
+
         "label" : "BatchCom",
         "menu_id" : "adm0",
         "target" : "msc",
         "url" : "/interface/batchcom/batchcom.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Pass Phrase",
         "menu_id" : "pwd0",
         "target" : "msc",
         "url" : "/interface/usergroup/user_info.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Preferences",
         "menu_id" : "prf0",
         "target" : "msc",
         "url" : "/interface/super/edit_globals.php?mode=user",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "New Documents",
         "menu_id" : "adm0",
         "target" : "msc",
         "url" : "/controller.php?document&list&patient_id=00",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Utilities",
-        "children" : [ { 
+        "children" : [ {
             "label" : "Validate Attached Documents",
             "menu_id" : "adm0",
             "target" : "msc",
@@ -936,7 +936,7 @@
             "requirement" : 0
         } ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Document Templates",
         "menu_id" : "adm0",
         "target" : "msc",
@@ -945,59 +945,59 @@
         "requirement" : 0
     } ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "Popups",
     "menu_id" : "popup",
-    "children" : [ { 
+    "children" : [ {
         "label" : "Issues",
         "menu_id" : "Popup:Issues",
         "url" : "/interface/patient_file/problem_encounter.php",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Export",
         "menu_id" : "Popup:Export",
         "url" : "/interface/../custom/export_xml.php",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Import",
         "menu_id" : "Popup:Import",
         "url" : "/interface/../custom/import_xml.php",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Appts",
         "menu_id" : "Popup:Appts",
         "url" : "/interface/reports/appointments_report.php?patient=",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Superbill",
         "menu_id" : "Popup:Superbill",
         "url" : "/interface/patient_file/printed_fee_sheet.php?fill=1",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Payment",
         "menu_id" : "Popup:Payment",
         "url" : "/interface/patient_file/front_payment.php",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Letter",
         "menu_id" : "Popup:Letter",
         "url" : "/interface/patient_file/letter.php",
         "target" : "pop",
         "children" : [ ],
         "requirement" : 1
-    }, { 
+    }, {
         "label" : "Chart Label",
         "menu_id" : "Popup:Chart Label",
         "url" : "/interface/patient_file/label.php",
@@ -1005,7 +1005,7 @@
         "children" : [ ],
         "requirement" : 1,
         "global_req" : "chart_label_type"
-    }, { 
+    }, {
         "label" : "Barcode Label",
         "menu_id" : "Popup:Barcode Label",
         "url" : "/interface/patient_file/barcode_label.php",
@@ -1013,7 +1013,7 @@
         "children" : [ ],
         "requirement" : 1,
         "global_req" : "barcode_label_type"
-    }, { 
+    }, {
         "label" : "Address Label",
         "menu_id" : "Popup:Address Label",
         "url" : "/interface/patient_file/addr_label.php",
@@ -1023,17 +1023,17 @@
         "global_req" : "addr_label_type"
     } ],
     "requirement" : 0
-}, { 
+}, {
     "label" : "QA Measures",
     "menu_id" : "mips",
-    "children" : [ { 
+    "children" : [ {
         "label" : "View Reports",
         "menu_id" : "rep0",
         "target" : "rep",
         "url" : "/modules/MIPS/report_results.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Create MIPS Report",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1041,7 +1041,7 @@
         "children" : [ ],
         "requirement" : 0,
         "global_req" : "enable_pqrs"
-    }, { 
+    }, {
         "label" : "Select Measures",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1049,7 +1049,7 @@
         "children" : [ ],
         "requirement" : 0,
         "global_req" : "enable_pqrs"
-    }, { 
+    }, {
         "label" : "Upload Claim Files",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1057,8 +1057,8 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ]
-    }, { 
- 
+    }, {
+
         "label" : "Instance Counts",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1066,8 +1066,8 @@
         "children" : [ ],
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
-        "global_req" : "enable_pqrs" 
-    }, { 
+        "global_req" : "enable_pqrs"
+    }, {
         "label" : "Remove_Provider_Assignments",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1076,14 +1076,14 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "enable_pqrs"
-    }, { 
+    }, {
         "label" : "Provider Encounter Counts",
         "menu_id" : "rep0",
         "target" : "rep",
         "url" : "/modules/MIPS/provider_encounter_counts.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Database Import",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1101,7 +1101,7 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "enable_pqrs"
-    }, { 
+    }, {
         "label" : "Change Demo Database",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1110,7 +1110,7 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "pqrs_demosystem"
-    }, { 
+    }, {
         "label" : "MIPS Module Installer",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1119,14 +1119,14 @@
         "requirement" : 0,
         "acl_req" : [ "admin", "super" ],
         "global_req" : "enable_pqrs"
-    },{ 
+    },{
         "label" : "XML Editor",
         "menu_id" : "rep0",
         "target" : "rep",
         "url" : "/modules/MIPS/xmleditor/index.php",
         "children" : [ ],
         "requirement" : 0
-    }, { 
+    }, {
         "label" : "Alerts Log",
         "menu_id" : "rep0",
         "target" : "rep",
@@ -1136,10 +1136,10 @@
     } ],
     "requirement" : 0,
     "global_req" : "enable_pqrs"
-}, { 
+}, {
     "label" : "Help",
     "menu_id" : "modimg",
-    "children" : [ { 
+    "children" : [ {
         "label" : "About",
         "menu_id" : "adm0",
         "target" : "pat",


### PR DESCRIPTION
Trying to open "Search or Add Patient" tab by going main menu > Patient/Client > Add New/Search results in following blank tab to open:
![empty](https://user-images.githubusercontent.com/25399108/41790163-468fc33c-766f-11e8-9501-5d76b8f92a92.JPG)

It happens because link to this tab isn't updated in menu_data.json while changing tab's file from `interface/new/new.php` to `interface/new/new_comprehensive.php` in #1173. @aethelwulffe Please have a look.