### PR TITLE
Fix iziModal - updater opening

### DIFF
--- a/interface/main/tabs/templates/tabs_template.php
+++ b/interface/main/tabs/templates/tabs_template.php
@@ -30,7 +30,7 @@
             <div class="body_title tabControls">
                 <span class="tabSpan bgcolor2">
                     <span  data-bind="text: title, click: tabClicked, css: {tabHidden: !visible()}"></span>
-                    <span class="fa fa-refresh tab-button" data-bind="click: tabRefresh" title="Refresh"></span>
+                    <span class="fa fa-refresh tab-refresh-icon tab-button" data-bind="click: tabRefresh" title="Refresh"></span>
                     <!--ko if:!locked() -->
                         <span class="fa fa-unlock tab-button"  data-bind="click: tabLockToggle" title="Unlock"></span>
                     <!-- /ko -->


### PR DESCRIPTION
If you inspect element on @naveen17797 's updater-icon, you can see the `<i class="fa fa-refresh"></i>` which is used for updater button's icon from font awesome library. Now, the tab refresh icon element is `<span class="fa fa-refresh tab-button" data-bind="click: tabRefresh" title="Refresh"></span>`. They both have common class fa-refresh because they both have same refresh type icon.

So, when we close iziModal, the function with property `onClosed` below finds all such elements on screen with `fa-refresh` class which in this case includes all refresh icons of tabs which are open as well as updater icon and then clicks on all of it using parent.$(".fa-refresh").click();. Eventually, we are not only directing all tabs to refresh upon closing of iziModal but **also updater to open up**, which is the current issue.

This PR adds a `class = "tab-refresh-icon"` to refresh icon element of tabs, so that by using `parent.$(".tab-refresh-icon").click()` instead of `parent.$(".fa-refresh").click()` in iziModal code (in `initIziLink(link)` function) below:

`onClosed: function () {`

                      setTimeout(function () {
                          parent.$(".fa-refresh").click();
                       }, 300);

`}`

would refresh all open tabs upon closing of iziModal and also not trigger opening of updater. This `initIziLink(link)` function is used whenever dynamic links are required in iziModal and `onClosed` property is used to refresh all open tabs upon closing of iziModal which is necessary in case of dynamic links. @muarachmann 

@teryhill I tested this after changing class (in `parent.$(".fa-refresh").click();`) in case of both log window in audit feature and also edit facilities iziModal, works. Please have a look.