### PR TITLE
GSoC 2018 : Calendar Improvements-Repeat parameters in Calendar Admin

### DIFF
--- a/library/appointments.inc.php
+++ b/library/appointments.inc.php
@@ -594,7 +594,7 @@ function fetchAppointmentCategories( $appt_prov_inc = false )
        $where = "pc_active = 1 ";
     }
 
-     $catSQL= " SELECT pc_catid as id, pc_catname as category, pc_catid, pc_catname, pc_cattype, pc_recurrtype, pc_duration, pc_end_all_day "
+     $catSQL= " SELECT pc_catid as id, pc_catname as category, pc_catid, pc_catname, pc_cattype, pc_recurrtype, pc_recurrspec, pc_enddate, pc_duration, pc_end_all_day "
             . " FROM libreehr_postcalendar_categories " .
               "WHERE " . $where .
               "ORDER BY " . $order;

--- a/modules/calendar/add_edit_event.php
+++ b/modules/calendar/add_edit_event.php
@@ -1033,7 +1033,8 @@ td { font-size:0.8em; }
  // var rectypes  = new Array();
 <?php
  // Read the event categories, generate their options list, and get
- // the default event duration from them if this is a new event.
+ // the default event duration & default recurring parameters corresponding to selected category
+ // from them if this is a new event.
  $cattype=0;
  if($_GET['prov']==true){
   $cattype=1;
@@ -1046,6 +1047,7 @@ td { font-size:0.8em; }
   $thisduration = $row['pc_alldayevent'] ? 1440 : round($row['pc_duration'] / 60);
  }
  while ($crow = sqlFetchArray($cres)) {
+  // loop through all rows of table libreehr_postcalendar_categories
   $duration = round($crow['pc_duration'] / 60);
     if ($crow['pc_end_all_day']) {
         $duration = 1440;
@@ -1074,8 +1076,16 @@ td { font-size:0.8em; }
       }
   } else {
    if ($crow['pc_catid'] == $default_catid) {
+    // when category row from table libreehr_postcalendar_categories matches selected category
     $catoptions .= " selected";
-    $thisduration = $duration;
+    $thisduration = $duration; // set default duration corresponding to selected category
+    // set default recurring parameters corresponding to selected category
+    $repeats = $crow['pc_recurrtype'];
+    $rspecs = unserialize($crow['pc_recurrspec']); // extract recurring data
+    $repeattype = $rspecs['event_repeat_freq_type'];
+    $repeatfreq = $rspecs['event_repeat_freq'];
+    $repeatexdate = $rspecs['exdate'];
+    $repeatenddate = $crow['pc_enddate'];
    }
   }
   $catoptions .= ">" . text(xl_appt_category($crow['pc_catname'])) . "</option>\n";
@@ -1760,13 +1770,11 @@ if  ($GLOBALS['select_multi_providers']) {
 
   </td>
  </tr>
-
     <style>
         #days_every_week_row input[type="checkbox"]{float:right;}
         #days_every_week_row div{display: inline-block; text-align: center; width: 12%;}
         #days_every_week_row div input{width: 100%;}
     </style>
-
 <tr id="days_every_week_row">
     <td></td>
     <td></td>
@@ -1798,7 +1806,6 @@ if  ($GLOBALS['select_multi_providers']) {
     </td>
 
 </tr>
-
  <tr>
   <td nowrap>
    <span id='title_apptstatus'><b><?php echo xlt('Status'); ?>:</b></span>
@@ -1823,14 +1830,20 @@ if(($_GET['prov']!=true) ){
    </select>
 
   </td>
-  <td nowrap>&nbsp;
-
-  </td>
+  <?php
+    if ($eid) {
+        // if existing event
+        $until_enddate = $row['pc_endDate'];
+    } else {
+        // if new event
+        $until_enddate = $repeatenddate; // show default end date corresponding to selected category
+    }
+  ?>
+  <td nowrap>&nbsp;</td>
   <td nowrap id='tdrepeat2'><?php echo xlt('until'); ?>
   </td>
   <td nowrap>
-   <input type='text' size='10' name='form_enddate' id='form_enddate'
-          value='<?php echo oeFormatShortDate(attr($row['pc_endDate'])) ?>'/>
+   <input type='text' size='10' name='form_enddate' id='form_enddate' value='<?php echo oeFormatShortDate(attr($until_enddate)) ?>'/>
 <?php
 if ($repeatexdate != "") {
     $tmptitle = "The following dates are excluded from the repeating series";

--- a/modules/calendar/admin.php
+++ b/modules/calendar/admin.php
@@ -2,17 +2,65 @@
 require_once("../../interface/globals.php");
 require_once("$srcdir/headers.inc.php");
 require_once("includes/admin_helper.php");
+require_once($GLOBALS['srcdir']."/formatting.inc.php");
 
 // get bootstrap
   call_required_libraries(array("jquery-min-3-1-1","bootstrap"));
 
+// set up working variables related to repeated events
+$my_recurrtype = 0;
+$my_repeat_freq = 0 + $_POST['form_repeat_freq'];
+$my_repeat_type = 0 + $_POST['form_repeat_type'];
+$my_repeat_on_num  = 1;
+$my_repeat_on_day  = 0;
+$my_repeat_on_freq = 0;
+$my_enddate = $_POST['form_enddate'];
+// if recurring appointment is to be set using new repeat mechanism, i.e., using 'days every week' mechanism
+if (!empty($_POST['days_every_week'])) {
+  $my_recurrtype = 3;
+  // loop through "days" checkboxes and insert selected days into array
+  $days_every_week_arr = array();
+  for ($i=1; $i<=7; $i++) {
+    if (!empty($_POST['day_' . $i])) {
+      array_push($days_every_week_arr, $i);
+    }
+  }
+  $my_repeat_freq = implode(",", $days_every_week_arr); // store that array as a string
+  $my_repeat_type = 6;
+} elseif (!empty($_POST['form_repeat'])) {
+  // if recurring appointment is to be set using old repeat mechanism, i.e., using 'every day', 'every 2nd day', etc.
+  $my_recurrtype = 1;
+}
+// capture the recurring specifications
+$recurrspec = array("event_repeat_freq" => "$my_repeat_freq",
+                    "event_repeat_freq_type" => "$my_repeat_type",
+                    "event_repeat_on_num" => "$my_repeat_on_num",
+                    "event_repeat_on_day" => "$my_repeat_on_day",
+                    "event_repeat_on_freq" => "$my_repeat_on_freq",
+                    "exdate" => $_POST['form_repeat_exdate']
+                  );
+// $noRecurrspec is used in case a category has no recurring specifications
+$noRecurrspec = array("event_repeat_freq" => "",
+                      "event_repeat_freq_type" => "",
+                      "event_repeat_on_num" => "1",
+                      "event_repeat_on_day" => "0",
+                      "event_repeat_on_freq" => "0",
+                      "exdate" => ""
+                    );
+// when both "Repeats" and "Days of Week" boxes are unchecked
+if ($my_recurrtype === 0) {
+  $recurrspec = $noRecurrspec;
+  $my_enddate =  "0000-00-00";
+}
+// serialize like in DB
+$recurrspec = serialize($recurrspec);
 
 // if update category button is used
 if($_POST['updateCat'] == 1) {
   // call for creation/updation of category
-  createUpdateCategory($_SESSION['category'], $_POST['catName'], $_POST['catCol'], 
-    $_POST['catDes'], $_POST['catType'], $_POST['catDur'], 
-    $_POST['catAllDay'], $_SESSION['category'] == "__NEW__");
+  createUpdateCategory($_SESSION['category'], $_POST['catName'], $_POST['catCol'],
+  $_POST['catDes'], $_POST['catType'], $_POST['catDur'], $my_recurrtype, $recurrspec, $my_enddate,
+  $_POST['catAllDay'], $_SESSION['category'] == "__NEW__");
 }
 
 // if delete category button is used
@@ -51,13 +99,13 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
 <body>
   <div class="container-fluid">
     <div class="row block cat-body">
-      
+
       <form class="form-horizontal" id="cat-select-form" action="" method="POST">
         <div class="form-group col-xs-12">
           <label for="category"><?php echo xlt('Select Category');?></label>
           <select class="form-control" id="category" name="category" required>
            <option value="__NEW__" select="selected"><?php echo xlt('New Category');?></option>
-            <?php 
+            <?php
             if (empty($_SESSION['category'])) {
                 error_log("nul?: ".$_SESSION['category'], 0);
                 $_SESSION['category'] = "__NEW__";
@@ -65,7 +113,7 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
             foreach($categories as $category) {
               $catid = $category['pc_catid'];
               $catname = $category['pc_catname'];
-              echo "<option value='$catid'"; 
+              echo "<option value='$catid'";
                 if($catid == $_SESSION['category']) {
                   echo " selected";
                 }
@@ -75,9 +123,9 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
           </select>
         </div>
       </form>
-      
+
     </div>
-  
+
     <div class="row block">
       <div class="cat-head">
         <?php
@@ -89,17 +137,17 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
           }
         ?>
       </div>
-      <form class="form-horizontal cat-body" action="" method="POST">
-        
+      <form class="form-horizontal cat-body" id="cat-field-form" action="" method="POST">
+
         <div class="row">
           <div class="form-group col-xs-6">
             <label class="control-label col-md-2" for="catName"><?php echo xlt('Name');?></label>
             <div class="col-md-10">
-              <input type="text" class="form-control" id="catName" name="catName" placeholder="<?php echo xlt('Category Name');?>" required 
+              <input type="text" class="form-control" id="catName" name="catName" placeholder="<?php echo xlt('Category Name');?>" required
               <?php if(!empty($selectedCat)) echo " value=\"" . $selectedCat['pc_catname'] . "\"";  ?> >
             </div>
           </div>
-          
+
           <div class="form-group col-xs-6">
             <label class="control-label col-md-2" for="catCol"><?php echo xlt('Color');?></label>
             <div class="col-md-10">
@@ -109,17 +157,17 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
             </div>
           </div>
         </div>
-        
+
         <div class="row">
           <div class="form-group col-xs-6">
             <label class="control-label col-md-2" for="catDur"><?php echo xlt('Duration (Minutes)');?></label>
             <div class="col-md-10">
               <input type="number" class="form-control" id="catDur" name="catDur" placeholder="<?php echo xlt('Minutes');?>" required
-              <?php if(!empty($selectedCat)) echo " value=\"" . $selectedCat['pc_duration']/60 . "\"" ?> 
+              <?php if(!empty($selectedCat)) echo " value=\"" . $selectedCat['pc_duration']/60 . "\"" ?>
               <?php if(!empty($selectedCat) && $selectedCat['pc_end_all_day'] == 1) echo " disabled"; ?> >
             </div>
           </div>
-          
+
           <div class="form-group col-xs-6">
             <label class="control-label col-md-2" for="catAllDay"><?php echo xlt('All Day');?></label>
             <div class="col-md-10">
@@ -134,16 +182,16 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
             </div>
           </div>
         </div>
-      
+
         <div class="row">
           <div class="form-group col-xs-6">
             <label class="control-label col-md-2" for="catDes"><?php echo xlt('Description');?></label>
             <div class="col-md-10">
-              <textarea rows="2" class="form-control" id="catDes" name="catDes" placeholder="<?php echo xlt('Category Description');?>" 
+              <textarea rows="2" class="form-control" id="catDes" name="catDes" placeholder="<?php echo xlt('Category Description');?>"
               required><?php if(!empty($selectedCat)) echo $selectedCat['pc_catdesc']; ?></textarea>
             </div>
           </div>
-          
+
           <div class="form-group col-xs-6">
             <label class="control-label col-md-2" for="catType"><?php echo xlt('Type');?></label>
             <div class="col-md-10">
@@ -155,53 +203,300 @@ if(isset($_SESSION['category']) && $_SESSION['category']!=NULL) {
             </div>
           </div>
         </div>
-        
+        <style>
+          .box{
+            border: ;
+          }
+        </style>
         <div class="row">
-          <div class="form-group col-xs-9"> 
+          <div class="form-group col-xs-6">
+            <label class="control-label col-md-2 box" for="catDes"><?php echo xlt('Repeat Parameters');?></label>
+            <div class="col-md-10 box">
+              <?php
+                /*
+                Functions 'isDaysEveryWeek' and 'isRegularRepeat' are used to check which repeating mechanism (new or old) is being used, and load settings in the event panel form accordingly.
+                */
+
+                // check if recurring appointment is to be set using new repeat mechanism, i.e., using 'days every week' mechanism
+                function isDaysEveryWeek($repeat) {
+                  if($repeat == 3){
+                    return true;
+                  } else {
+                    return false;
+                  }
+                }
+
+                // check if recurring appointment is to be set using old repeat mechanism, i.e., using 'every day', 'every 2nd day', etc.
+                function isRegularRepeat($repeat) {
+                  if($repeat == 1 || $repeat == 2){
+                    return true;
+                  } else {
+                    return false;
+                  }
+                }
+
+                // if no existing category is selected, then:
+                if (!empty($selectedCat)) {
+                  $repeats = 0; // don't check "Repeats" and "Days of Week" boxes
+                  $repeattype = '0'; // stores "day/workday/week" option in regular repeat
+                  $repeatfreq = '0'; // stores "Every" option in regular repeat or "Days" checkboxes in 'days every week' repeat
+                  $enddate = ""; // stores end date of "until" input
+                } else {
+                  // otherwise, load the values from DB corresponding to selected category
+                  $repeats = $selectedCat['pc_recurrtype'];
+                  // parse out the repeating data, if any:
+                  $rspecs = unserialize($selectedCat['pc_recurrspec']); // extract recurring data
+                  $repeattype = $rspecs['event_repeat_freq_type'];
+                  $repeatfreq = $rspecs['event_repeat_freq'];
+                  $repeatexdate = $rspecs['exdate']; // repeating date exceptions
+                  // adjustments for repeat type 2, a particular weekday of the month
+                  if ($repeats == 2) {
+                    $repeatfreq = $rspecs['event_repeat_on_freq'];
+                    if ($rspecs['event_repeat_on_num'] < 5) {
+                      $repeattype = 5;
+                    } else {
+                      $repeattype = 6;
+                    }
+                  }
+                  $enddate = $selectedCat['pc_enddate'];
+                }
+              ?>
+              <table class="box">
+                <!-- first row of repeat parameters -->
+                <tr class="box">
+                  <td>
+                    <input type='checkbox' name='form_repeat' id='form_repeat' value='1'<?php if (isRegularRepeat($repeats)) echo " checked" ?>/>
+                    <input type='hidden' name='form_repeat_exdate' id='form_repeat_exdate' value='<?php echo attr($repeatexdate); ?>' /> <!-- dates excluded from the repeat -->
+                  </td>
+                  <td id='repeats_label'>&nbsp;<?php echo xlt('Repeats'); ?></td>
+                  <td>
+                    <select name='form_repeat_freq' id="form_repeat_freq" title='<?php echo xla('Every, every other, every 3rd, etc.'); ?>'>
+                    <?php
+                      $freq_options = array(1 => xl('every'), 2 => xl('2nd'), 3 => xl('3rd'), 4 => xl('4th'), 5 => xl('5th'), 6 => xl('6th'));
+                      foreach ($freq_options as $key => $value) {
+                        echo "<option value='" . attr($key) . "'";
+                        if ($key == $repeatfreq && isRegularRepeat($repeats)) {
+                          echo " selected";
+                        }
+                        echo ">" . text($value) . "</option>\n";
+                      }
+                    ?>
+                    </select>
+                    <select name='form_repeat_type' id="form_repeat_type">
+                    <?php
+                      $type_options = array(0 => xl('day') , 4 => xl('workday'), 1 => xl('week'), 2 => xl('month'), 3 => xl('year'));
+                      foreach ($type_options as $key => $value) {
+                        echo "<option value='" . attr($key) . "'";
+                        if ($key == $repeattype && isRegularRepeat($repeats)) {
+                          echo " selected";
+                        }
+                        echo ">" . text($value) . "</option>\n";
+                      }
+                    ?>
+                    </select>
+                  </td>
+                </tr>
+                <!-- first row of repeat parameters-->
+                <style>
+                  #days_every_week_row input[type="checkbox"]{
+                    float:right;
+                  }
+                  #days_every_week_row div{
+                    display: inline-block;
+                    text-align: center;
+                    width: 12%;
+                  }
+                  #days_every_week_row div input{
+                    width: 100%;
+                  }
+                </style>
+                <!-- second row of repeat parameters -->
+                <tr id="days_every_week_row" class="box">
+                  <td>
+                    <input type='checkbox' id='days_every_week' name='days_every_week' <?php echo isDaysEveryWeek($repeats) ? " checked" : null ?> />
+                  </td>
+                  <td id="days_label">&nbsp;<?php echo xlt('Days Of Week') . ":"; ?>&nbsp;</td>
+                  <td id="days">
+                  <?php
+                    $weekdays = array(1 => xl('Su{{Sunday}}') , 2 => xl('M{{Monday}}'), 3 => xl('Tu{{Tuesday}}'), 4 => xl('W{{Wednesday}}'),
+                     5 => xl('Th{{Thursday}}'), 6 => xl('F{{Friday}}'), 7 => xl('Sa{{Saturday}}'));
+                    foreach ($weekdays as $key => $value) {
+                      echo " <div><input type='checkbox' name='day_". attr($key) ."'";
+                      // checks appropriate boxes according to days in string $repeatfreq
+                      if (in_array($key, explode(',', $repeatfreq)) && isDaysEveryWeek($repeats)) {
+                        echo " checked";
+                      }
+                      echo " /><label>" . text($value) . "</label></div>\n";
+                    }
+                  ?>
+                  </td>
+                </tr>
+                <!-- second row of repeat parameters -->
+
+                <!-- third row of repeat parameters -->
+                <tr class="box">
+                  <td>&nbsp;</td>
+                  <td id='endDate_label'>&nbsp;<?php echo xlt('until'); ?></td>
+                  <td>
+                    <input type='text' size='10' name='form_enddate' id='form_enddate' value='<?php echo oeFormatShortDate(attr($enddate)) ?>'/>
+                    <?php
+                      if ($repeatexdate != "") {
+                        $tmptitle = "The following dates are excluded from the repeating series";
+                        if ($multiple_value) {
+                          $tmptitle .= " for one or more providers:\n";
+                        } else {
+                          $tmptitle .= "\n";
+                        }
+                        $exdates = explode(",", $repeatexdate);
+                        foreach ($exdates as $exdate) {
+                          $tmptitle .= date("d M Y", strtotime($exdate))."\n";
+                        }
+                        echo "<a href='#' title='" . attr($tmptitle) . "' alt='" . attr($tmptitle) . "'><img src='../../interface/pic/warning.gif' title='" . attr($tmptitle) . "' alt='*!*' style='border:none;'/></a>";
+                      }
+                    ?>
+                  </td>
+                </tr>
+                <!-- third row of repeat parameters -->
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="form-group col-xs-9">
             <div class=col-md-12>
               <button type="submit" class="btn btn-primary cp-positive" name="updateCat" value="1"><?php echo xlt('Update');?></button>
             </div>
           </div>
-          
+
           <!-- show delete button only if you select a category -->
           <?php if(!empty($selectedCat)) { ?>
           <div class="form-group col-xs-3">
             <div class=col-md-12>
-              <button type="submit" class="btn btn-danger cp-negative" name="deleteCat" value="1" 
+              <button type="submit" class="btn btn-danger cp-negative" name="deleteCat" value="1"
               onclick="return confirm('<?php echo xlt('Are you sure you want to do that?');?>');"><?php echo xlt('Delete');?></button>
             </div>
           </div>
           <!-- end if -->
           <?php } ?>
-          
+
         </div>
-        
+
       </form>
     </div>
   </div>
-    
-    <script>
+
+  <script type="text/javascript">
     // selector for category submits the form
     $("#category").change(function() { $('#cat-select-form').submit(); });
-    
+
     // change card color according to selected color
     $('.cat-head').css("background", $("#catCol").val());
     $("#catCol").change(function() { $('.cat-head').css("background", $("#catCol").val());});
-    
+
     // disable duration if all day is selected
     $('#allDay1').click(function () {
         if ($(this).is(':checked')) {
           $("#catDur").prop("disabled", true);
         }
     });
-    
+
     // enale duration if not all day
     $('#allDay0').click(function () {
         if ($(this).is(':checked')) {
-          $("#catDur").prop("disabled", false);  
+          $("#catDur").prop("disabled", false);
         }
     });
-    </script>
-    
+
+    // if no category is selected, disable all repeat parameters fields
+    // initially, upon loading of form
+  <?php if (empty($selectedCat)) { ?>
+    set_repeat();
+    set_days_every_week();
+  <?php } ?>
+
+    // modify some visual attributes when:
+    // 1. "Repeats" checkbox is clicked
+    $("#form_repeat").on("click", function () {
+      set_repeat();
+    });
+    function set_repeat() {
+      var f = document.getElementById("cat-field-form");
+      var isdisabled = true;
+      var mycolor = '#777777';
+      var myvisibility = 'hidden';
+      if (f.form_repeat.checked) {
+        // uncheck "Days of Week" checkbox
+        f.days_every_week.checked = false;
+        // and disable, make grey all input related to it
+        document.getElementById("days_label").style.color = mycolor;
+        var days = document.getElementById("days").getElementsByTagName("input");
+        var labels = document.getElementById("days").getElementsByTagName("label");
+        for (var i = 0; i < days.length; i++) {
+          days[i].disabled = isdisabled;
+          labels[i].style.color = mycolor;
+        }
+        isdisabled = false;
+        mycolor = '#000000';
+        myvisibility = 'visible';
+      }
+      // if "Repeats" is checked, enable all input related to it
+      // if "Repeats" is unchecked, disable and make grey all input related to it
+      f.form_repeat_type.disabled = isdisabled;
+      f.form_repeat_freq.disabled = isdisabled;
+      f.form_enddate.disabled = isdisabled;
+      document.getElementById("form_repeat_freq").style.color = mycolor;
+      document.getElementById("form_repeat_type").style.color = mycolor;
+      document.getElementById("repeats_label").style.color = mycolor;
+      document.getElementById("endDate_label").style.color = mycolor;
+      document.getElementById("form_enddate").style.color = mycolor;
+    }
+
+    // 2. "Days Of Week" checkbox is clicked
+    $("#days_every_week").on("click", function () {
+      set_days_every_week();
+    });
+    function set_days_every_week() {
+      var f = document.getElementById("cat-field-form");
+      if (f.days_every_week.checked) {
+        // if "Days Of Week" is checked then,
+        // uncheck "Repeats" checkbox
+        // and disable, make grey all input related to it
+        f.form_repeat.checked = false;
+        f.form_repeat_type.disabled = true;
+        f.form_repeat_freq.disabled = true;
+        f.form_enddate.disabled = false;
+        document.getElementById("form_repeat_freq").style.color = '#777777';
+        document.getElementById("form_repeat_type").style.color = '#777777';
+        document.getElementById("repeats_label").style.color = '#777777';
+        // enable all input related to "Days of Week"
+        document.getElementById("endDate_label").style.color = '#000000';
+        document.getElementById("form_enddate").style.color = '#000000';
+        var isdisabled = false;
+        var mycolor = '#000000';
+        var myvisibility = 'visible';
+      } else {
+        // "Days Of Week" is not checked
+        // disable and make grey all input related to it
+        var isdisabled = true;
+        var mycolor = '#777777';
+        var myvisibility = 'hidden';
+      }
+      document.getElementById("days_label").style.color = mycolor;
+      var days = document.getElementById("days").getElementsByTagName("input");
+      var labels = document.getElementById("days").getElementsByTagName("label");
+      for (var i = 0; i < days.length; i++) {
+        days[i].disabled = isdisabled;
+        labels[i].style.color = mycolor;
+      }
+      // if both "Repeats" and "Days of Week" boxes are unchecked
+      if(!f.days_every_week.checked  && !f.form_repeat.checked){
+        // disable end_date ("until") input
+        document.getElementById("endDate_label").style.color = mycolor;
+        f.form_enddate.disabled = isdisabled;
+        document.getElementById("form_enddate").style.color = mycolor;
+      }
+    }
+  </script>
 </body>
 </html>

--- a/modules/calendar/includes/admin_helper.php
+++ b/modules/calendar/includes/admin_helper.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 function getCategories() {
   $query = "SELECT * FROM libreehr_postcalendar_categories ORDER BY pc_catname;";
@@ -6,24 +6,25 @@ function getCategories() {
   return $res;
 }
 
-function createUpdateCategory($catid, $catname, $catcol, $catdes, $cattype, $durmins, $allday, $new=TRUE) {
+function createUpdateCategory($catid, $catname, $catcol, $catdes, $cattype, $durmins, $recurrtype, $recurrspec, $enddate, $allday, $new=TRUE) {
   if($allday == 1) {
     $duration = 0;
   } else {
     $duration = $durmins*60;
   }
-  
+
   if($new) {
-    $query = "INSERT INTO libreehr_postcalendar_categories(pc_catname, 
+    $query = "INSERT INTO libreehr_postcalendar_categories(pc_catname,
       pc_catcolor, pc_catdesc, pc_cattype, pc_duration, pc_end_all_day)
-      VALUES(?, ?, ?, ?, ?, ?);";
-      $res = sqlStatement($query, array($catname, $catcol, $catdes, $cattype, $duration, $allday));
+      VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);";
+      $res = sqlStatement($query, array($catname, $catcol, $catdes, $cattype, $duration, $recurrtype, $recurrspec, $enddate, $allday));
   } else {
-    $query = "UPDATE libreehr_postcalendar_categories SET 
+    $query = "UPDATE libreehr_postcalendar_categories SET
       pc_catname = ?, pc_catcolor = ?, pc_catdesc = ?,
-      pc_cattype = ?, pc_duration = ?, pc_end_all_day = ? 
+      pc_cattype = ?, pc_duration = ?, pc_recurrtype = ?,
+      pc_recurrspec = ?, pc_enddate = ?, pc_end_all_day = ?
       WHERE pc_catid = ?;";
-    $res = sqlStatement($query, array($catname, $catcol, $catdes, $cattype, $duration, $allday, $catid));
+    $res = sqlStatement($query, array($catname, $catcol, $catdes, $cattype, $duration, $recurrtype, $recurrspec, $enddate, $allday, $catid));
   }
   return $res;
 }


### PR DESCRIPTION
Fixes #767 

Repeat parameters are added in Calendar Admin so that a set of repeat parameters settings can be stored with respect to an existing category or new category and can be accessed as default settings of repeat parameters corresponding to the selected category in patient or provider event panel.

Preview:
![rp](https://user-images.githubusercontent.com/25399108/42389104-41c37596-8165-11e8-96a7-95aa2e213f33.JPG)

Work done:
1) Added repeat parameters in calendar admin (admin.php) as they were in event panel (add_edit_event.php).
2) Made some changes in admin.php and admin_helper.php so that they store and display settings as selected by user.
3) Made some changes in add_edit_event.php and appointments.inc.php so that event panel displays default settings in repeat parameters in case of new event corresponding to selected category.

@teryhill Please have a look.