### PR TITLE
Provider scroll in Calendar's agenda views

### DIFF
--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -51,7 +51,8 @@ require('includes/session.php');
     }
 
     .fc-agenda-view > table {
-        width: 1200px;
+        width: var(--col-width, 1200px);
+        overflow-wrap: break-word;
     }
   </style>
 </head>
@@ -184,6 +185,15 @@ require('includes/session.php');
           $('#calendar').fullCalendar('option', 'contentHeight', 340);
         } else {
           $('#calendar').fullCalendar('option', 'contentHeight', 280);
+        }
+      }
+
+      function resizeAgendaViewTable(providers) {
+        // to change width of agenda view table based on number of providers
+        if (providers > 10) {
+          var toWidth = 120*providers; // taking ratio as 1200px for 10 providers
+          var bodyStyles = document.body.style;
+          bodyStyles.setProperty("--col-width", toWidth);
         }
       }
 
@@ -349,6 +359,9 @@ require('includes/session.php');
             $('#datepicker').datetimepicker({ value: view.intervalStart.format() });
 
             scrollCalTime(view);  // when view changes or any date navigation method (prev, next, today) is called
+            console.log("render");
+            var providers = $(".fc-resource-cell").length // number of provider column in agenda views
+            resizeAgendaViewTable(providers);
         },
         loading: function(isLoading, view) {
             // triggered when event or resource fetching starts/stops.
@@ -356,6 +369,7 @@ require('includes/session.php');
                 // fetching starts
                 scrollCalTime(view);  // when Calendar is loaded or refreshed
             } else {
+                console.log("loaded");
                 // fetching stops
                 providerScroll()  // make sure horizontal scroll bar is visible when Calendar info. is changed
             }

--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -38,6 +38,22 @@ require('includes/session.php');
   <script src="<?php echo $GLOBALS['standard_js_path']; ?>js.cookie/js.cookie.js"></script>
   <script src="<?php echo $GLOBALS['standard_js_path']; ?>jquery-datetimepicker/jquery.datetimepicker.full.min.js"></script>
   <script src="../../library/dialog.js"></script>
+
+  <style type="text/css">
+  /* style to provide horizontal scroll in Calendar's agenda views
+     by making table overflow its container */
+    .fc-view-container {
+        width: auto;
+    }
+
+    .fc-agenda-view {
+        overflow-x: scroll;
+    }
+
+    .fc-agenda-view > table {
+        width: 1200px;
+    }
+  </style>
 </head>
 <body>
   <div id="sidebar">
@@ -154,6 +170,21 @@ require('includes/session.php');
         var currCalTime = currHour + ":" + currMinutes + ":00";  // format "hh:mm:00"
         // scrollTime determines how much forward scroll pane is initially scrolled
         calView.options.scrollTime = currCalTime;  // set scrollTime to current time
+      }
+
+      function providerScroll() {
+        // Calendar tab's frame width - inner content + margin + space b/w frames
+        var calendarFrameWidth = $("#sidebar").width() + $("#calendar-container").width() + 16 + 7;
+        // setting height of the view area of the calendar so that horizontal scrollbar is visible
+        if (calendarFrameWidth > 580) {
+          $('#calendar').fullCalendar('option', 'contentHeight', 400);
+        } else if (calendarFrameWidth > 430) {
+          $('#calendar').fullCalendar('option', 'contentHeight', 370);
+        } else if (calendarFrameWidth > 390) {
+          $('#calendar').fullCalendar('option', 'contentHeight', 340);
+        } else {
+          $('#calendar').fullCalendar('option', 'contentHeight', 280);
+        }
       }
 
       $('#calendar').fullCalendar({
@@ -324,7 +355,14 @@ require('includes/session.php');
             if(isLoading) {
                 // fetching starts
                 scrollCalTime(view);  // when Calendar is loaded or refreshed
+            } else {
+                // fetching stops
+                providerScroll()  // make sure horizontal scroll bar is visible when Calendar info. is changed
             }
+        },
+        windowResize: function(view) {
+            // triggered when Calendar’s dimensions (frame width) changes due to opening/closing of other frames
+            providerScroll()  // make sure horizontal scroll bar is visible when frame width changes
         }
       })
 

--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -359,7 +359,6 @@ require('includes/session.php');
             $('#datepicker').datetimepicker({ value: view.intervalStart.format() });
 
             scrollCalTime(view);  // when view changes or any date navigation method (prev, next, today) is called
-            console.log("render");
             var providers = $(".fc-resource-cell").length // number of provider column in agenda views
             resizeAgendaViewTable(providers);
         },
@@ -369,7 +368,6 @@ require('includes/session.php');
                 // fetching starts
                 scrollCalTime(view);  // when Calendar is loaded or refreshed
             } else {
-                console.log("loaded");
                 // fetching stops
                 providerScroll()  // make sure horizontal scroll bar is visible when Calendar info. is changed
             }


### PR DESCRIPTION
Continuing #1203, initial commit adds a horizontal scroll bar for provider scroll in agenda views of Calendar. It works by making Calendar slot table overflow its container. One issue was disappearance of scroll bar because of height of `.fc-scroller` and had to add a function to make sure it's visible in all possible states.

@teryhill Please have a look.