### PR TITLE
Change facility dynamic iziModal refresh

### DIFF
--- a/interface/usergroup/facilities.php
+++ b/interface/usergroup/facilities.php
@@ -161,7 +161,7 @@ $(document).ready(function(){
         iframeURL: "facility_admin.php?fid=" + link,
         onClosed: function () {
           setTimeout(function () {
-            parent.$(".fa-refresh").click();
+            parent.$(".tab-refresh-icon").click();
           }, 300);
         }
       });


### PR DESCRIPTION
This PR covers the iziModal part of iziModal-tab refresh - updater opening issue with tab part covered in #1194. Since, updater (#1122) is now in code base with facility iziModal added in #1134, this initial commit fixes opening of updater after closing of facility edit modal. @teryhill Please have a look.