### PR TITLE
Provider at multiple facilities.

### DIFF
--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -60,15 +60,12 @@ require('includes/session.php');
         $facilities = getFacilities();
       } else {
         $facilities = getUserFacilities($_SESSION['authId']); // from users_facility
-        if (count($facilities) == 1)
-          $_SESSION['pc_facility'] = key($facilities);
       }
 
-      if (count($facilities) > 1) {
+      if (count($facilities) > 0) {
         echo "   <select name='pc_facility' id='pc_facility' >\n";
         if ( !$_SESSION['pc_facility'] ) $selected = "selected='selected'";
         echo "    <option value='0' $selected>"  .xl('All Facilities'). "</option>\n";
-
         foreach ($facilities as $fa) {
             $selected = ( $_SESSION['pc_facility'] == $fa['id']) ? "selected" : "" ;
             echo "    <option style=background-color:".htmlspecialchars($fa['color'],ENT_QUOTES)." value='" .htmlspecialchars($fa['id'],ENT_QUOTES). "' $selected>"  .htmlspecialchars($fa['name'],ENT_QUOTES). "</option>\n";


### PR DESCRIPTION
The facility select drop-down in Calendar's sidebar uses `getUserFacilities` function and table users_facility to get scheduled facilities of logged in user. Without global _Restrict Users to Facilities_ turned on, this feature won't work properly. If we are logged in as Admin, and we select two facilities A and B as schedule ones for Admin, then only these two would be shown in that drop-down along with "All facilities". 

When "All facilities" is selected, which is always by default, it shows all providers in sidebar and after selecting a particular facility from drop-down, only providers having that facility as schedule ones are shown in sidebar and on Calendar. This select option was not shown when logged in user had only one facility as scheduled one. Fixed this issue and now, if we select facility A and B as schedule ones for another provider, then this other provider would be shown in sidebar in both cases - when we select facility A and also when we select facility B in drop-down.

Therefore, now we can have a provider at multiple facilities. If the global isn't turned on, then this will work w.r.t to default facility and not scheduled facility and hence, a particular provider would only be shown in sidebar when that provider's default facility is selected from drop-down, limiting that provider to be at one facility only. Before testing, please make sure to delete all rows in users_facility and re-establish relations b/w providers and schedule facilities (similar to the one described in this PR).

@teryhill Please have a look. 