### PR TITLE
Improve performance of patient finder with tags on large DB

### DIFF
--- a/interface/tags_filters/migrations/Migration_2018_08_22_14_48_11.php
+++ b/interface/tags_filters/migrations/Migration_2018_08_22_14_48_11.php
@@ -1,0 +1,132 @@
+<?php
+
+use \Framework\Plugin\Migration\Migration;
+
+class Migration_2018_08_22_14_48_11 extends Migration
+{
+    public function up()
+    {
+        $directive = <<<MIGRATION
+--
+--  Comment Meta Language Constructs:
+--
+--  #IfNotTable
+--    argument: table_name
+--    behavior: if the table_name does not exist,  the block will be executed
+
+--  #IfTable
+--    argument: table_name
+--    behavior: if the table_name does exist, the block will be executed
+
+--  #IfMissingColumn
+--    arguments: table_name colname
+--    behavior:  if the colname in the table_name table does not exist,  the block will be executed
+
+--  #IfNotColumnType
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value, then the block will be executed
+
+--  #IfNotRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a row where colname = value, the block will be executed.
+
+--  #IfNotRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfNotRow3D
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfNotRow4D
+--    arguments: table_name colname value colname2 value2 colname3 value3 colname4 value4
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3 AND colname4 = value4, the block will be executed.
+
+--  #IfNotRow2Dx2
+--    desc:      This is a very specialized function to allow adding items to the list_options table to avoid both redundant option_id and title in each element.
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  The block will be executed if both statements below are true:
+--               1) The table table_name does not have a row where colname = value AND colname2 = value2.
+--               2) The table table_name does not have a row where colname = value AND colname3 = value3.
+
+--  #IfNotIndex
+--    desc:      This function will allow adding of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the index does not exist, it will be created
+
+--  #EndIf
+--    all blocks are terminated with and #EndIf statement.
+
+--
+-- Indexes for table `tf_patients_tags`
+--
+
+ALTER TABLE `tf_patients_tags`
+  ADD KEY `pid_index` (`pid`);
+
+
+MIGRATION;
+
+        return $directive;
+    }
+
+    public function down()
+    {
+        $directive = <<<MIGRATION
+--
+--  Comment Meta Language Constructs:
+--
+--  #IfNotTable
+--    argument: table_name
+--    behavior: if the table_name does not exist,  the block will be executed
+
+--  #IfTable
+--    argument: table_name
+--    behavior: if the table_name does exist, the block will be executed
+
+--  #IfMissingColumn
+--    arguments: table_name colname
+--    behavior:  if the colname in the table_name table does not exist,  the block will be executed
+
+--  #IfNotColumnType
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value, then the block will be executed
+
+--  #IfNotRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a row where colname = value, the block will be executed.
+
+--  #IfNotRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfNotRow3D
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfNotRow4D
+--    arguments: table_name colname value colname2 value2 colname3 value3 colname4 value4
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3 AND colname4 = value4, the block will be executed.
+
+--  #IfNotRow2Dx2
+--    desc:      This is a very specialized function to allow adding items to the list_options table to avoid both redundant option_id and title in each element.
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  The block will be executed if both statements below are true:
+--               1) The table table_name does not have a row where colname = value AND colname2 = value2.
+--               2) The table table_name does not have a row where colname = value AND colname3 = value3.
+
+--  #IfNotIndex
+--    desc:      This function will allow adding of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the index does not exist, it will be created
+
+--  #EndIf
+--    all blocks are terminated with and #EndIf statement.
+
+
+#EndIf
+MIGRATION;
+
+        return $directive;
+    }
+}


### PR DESCRIPTION
On a large DB, the join on the  tf_patient_tags pivot table caused big performance penalty, so I added a migration to insert an index to pid col of tf_patient_tags pivot table.