### PR TITLE
fixed broken link

### DIFF
--- a/modules/calendar/search.php
+++ b/modules/calendar/search.php
@@ -165,7 +165,7 @@ function keywordFilter($arr) {
     }
     
     function goPid(pid) {
-      top.RTop.location = '../../interface/patient_file/summary/demographics.php' + '?set_pid=' + pid;
+      top.RTop.location = '../../patient_file/summary/demographics.php' + '?set_pid=' + pid;
       
       // cancel event bubble trying to open add_edit_event
       if (!e) var e = window.event;


### PR DESCRIPTION
Fix for patient broken link from calendar search page. Procedure click on the search button of calendar. Search a patient between some start date and end date. Results displays quite alright. Now click on the patient name. --> RESULTS: 404 not found tab found.
![screenshot from 2018-09-06 15-43-21](https://user-images.githubusercontent.com/16350814/45189057-1b747e00-b205-11e8-8d8f-0735bc5ff490.png)

With new code 
![screenshot from 2018-09-06 15-46-18](https://user-images.githubusercontent.com/16350814/45189119-73ab8000-b205-11e8-9b16-42f03085a1c1.png)



