### PR TITLE
#1246: Calendar opens on medication outcome select <Resolved>

### DIFF
--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -552,7 +552,6 @@ ActiveIssueCodeRecycleFn($thispid, $ISSUE_TYPES);
    var today = new Date();
    f.form_end.value = '' + (today.getYear() + 1900) + '-' +
     ("0" + (today.getMonth() + 1)).slice(-2) + '-' + ("0" + today.getDate()).slice(-2);
-   f.form_end.focus();
   }
  }
 


### PR DESCRIPTION
Removed focus from End Date field on the Add issues form so that calendar does not pop up when outcome <Resolved> is selected.