### PR TITLE
Fix #1291: Tab Value Colors Changed to Blue from White

### DIFF
--- a/interface/themes/style_light.css
+++ b/interface/themes/style_light.css
@@ -759,10 +759,11 @@ ul.tabNav li {
 }
 ul.tabNav li.current a {
   background: #ffffff;
+  font-weight: bold;
   color: #2672ec;
 }
 ul.tabNav a {
-  color: #ffffff;
+  color: #2672ec;
   display: block;
   padding: 8px 17px;
   text-decoration: none;


### PR DESCRIPTION
Fixes #1291 for light theme.

**Description:**
Changed values in the css so that the tabs other than `current` would also appear as blue. Also made the `current` tab bold.

Note: I had an issue when I was bug hunting where I made changes to the css file but it didn't apply for some reason. I cleared all my Chrome data for the past 24 hours (since I installed EHR last night), and my changes started to register. Not sure what happened there though.

**GIF:**
![tabfix](https://user-images.githubusercontent.com/41968151/48852325-bb589700-ed72-11e8-991b-88585d2a845e.gif)