### PR TITLE
Fix #1301: Calendar title no longer changes

### DIFF
--- a/modules/calendar/search.php
+++ b/modules/calendar/search.php
@@ -39,11 +39,11 @@ function keywordFilter($arr) {
 </head>
 <body>
   
-  <div class="container-fluid">
-    <div class="row title">
+  <div class="container-fluid" style="margin-left: 20px; margin-right: 20px;">
+    <div class="row">
       <h2><button type="button" class="btn btn-default btn-sm" onclick="window.location.href='index.php'">Back to Calendar</button></h2>
     </div>
-    <div class="row title">
+    <div class="row">
       <h3>Search</h3>
     </div>
     


### PR DESCRIPTION
The title of the tab is always Calendar now. There is no reason to change it either to "Back to Calendar" or to "Search" or something like that. The tab is still related to Calendar so just keep the name. Added some margins inside the content to fit better.

![image](https://user-images.githubusercontent.com/6632800/49116992-41a33a80-f297-11e8-8149-b037da04f30b.png)
