### PR TITLE
Fix #1298: Lab Overview Title Not Displaying

### DIFF
--- a/interface/patient_file/summary/labdata.php
+++ b/interface/patient_file/summary/labdata.php
@@ -81,6 +81,7 @@ $main_spell .= "ORDER BY procedure_report.date_collected DESC ";
 // ####################################################
 echo "<html><head>";
 ?> 
+<title><?php echo xlt('Lab Overview'); ?></title>
 <link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css"> 
 <link rel="stylesheet" href="<?php echo $web_root; ?>/interface/themes/labdata.css" type="text/css"> 
 <script type="text/javascript" src="<?php echo $web_root; ?>/library/js/jquery.1.3.2.js"></script>


### PR DESCRIPTION
## Fixes #1298 

## Description
The issue was that the title was never declared in the respective php file. Just added the tag and it is fixed.

## Screenshot
![image](https://user-images.githubusercontent.com/41968151/49127558-6a263700-f28d-11e8-9121-c715f99f164f.png)