### PR TITLE
Fix #1275: Clinical Reports Enhancement (Dynamically Sized Inputs)

### DIFF
--- a/assets/js/DataTables-1.10.16/datatables.css
+++ b/assets/js/DataTables-1.10.16/datatables.css
@@ -822,6 +822,9 @@ a.dt-button.processing:after {
 }
 
 
+table thead tr th input {
+  width: 100%;
+}
 table.dataTable.dtr-inline.collapsed > tbody > tr > td.child,
 table.dataTable.dtr-inline.collapsed > tbody > tr > th.child,
 table.dataTable.dtr-inline.collapsed > tbody > tr > td.dataTables_empty {

--- a/interface/reports/clinical_stats_by_demographics_report.php
+++ b/interface/reports/clinical_stats_by_demographics_report.php
@@ -276,12 +276,12 @@ function show_all_diags(){
 	<thead>
 
         <tr>
-            <th><input  id = 'column0_search_show_diags_details_table' size="4"></th>
-            <th><input  id = 'column1_search_show_diags_details_table' size="4"></th>
-            <th><input  id = 'column2_search_show_diags_details_table' size="4"></th>
-            <th><input  id = 'column3_search_show_diags_details_table' size="4"></th>
-            <th><input  id = 'column4_search_show_diags_details_table' size="4"></th>
-            <th align="left"><input  id = 'column5_search_show_diags_details_table' size="4"></th>
+            <th><input  id = 'column0_search_show_diags_details_table'></th>
+            <th><input  id = 'column1_search_show_diags_details_table'></th>
+            <th><input  id = 'column2_search_show_diags_details_table'></th>
+            <th><input  id = 'column3_search_show_diags_details_table'></th>
+            <th><input  id = 'column4_search_show_diags_details_table'></th>
+            <th align="left"><input  id = 'column5_search_show_diags_details_table'></th>
         </tr>
 
 		<tr>

--- a/interface/reports/lab_stats_by_demographics_report.php
+++ b/interface/reports/lab_stats_by_demographics_report.php
@@ -236,13 +236,13 @@ $to_date = $to_date->format('Y-m-d');
     <thead>
 
     <tr>
-        <th><input  id = 'column0_search_show_lab_details_table' size="4"></th>
-        <th><input  id = 'column1_search_show_lab_details_table' size="4"></th>
-        <th><input  id = 'column2_search_show_lab_details_table' size="4"></th>
-        <th><input  id = 'column3_search_show_lab_details_table' size="4"></th>
-        <th><input  id = 'column4_search_show_lab_details_table' size="4"></th>
-        <th><input  id = 'column5_search_show_lab_details_table' size="4"></th>
-        <th><input  id = 'column6_search_show_lab_details_table' size="4"></th>
+        <th><input  id = 'column0_search_show_lab_details_table'></th>
+        <th><input  id = 'column1_search_show_lab_details_table'></th>
+        <th><input  id = 'column2_search_show_lab_details_table'></th>
+        <th><input  id = 'column3_search_show_lab_details_table'></th>
+        <th><input  id = 'column4_search_show_lab_details_table'></th>
+        <th><input  id = 'column5_search_show_lab_details_table'></th>
+        <th><input  id = 'column6_search_show_lab_details_table'></th>
 
 
     </tr>


### PR DESCRIPTION
## Fixes #1275 

## Description
The table columns adjust their height to the biggest length value in the column. However, the search bars do not follow suit. I added a css styling to make the width of the inputs 100%. The inputs will adjust to the size of the lengthiest data value in the column when data is populated (tested with inspect element in nhanes demo).

## Screenshots
![image](https://user-images.githubusercontent.com/41968151/49127984-1b799c80-f28f-11e8-96a7-0b2dc1ef5cd7.png)