### PR TITLE
Fix #1314: Style.php no longer overrides PRISM colors

### DIFF
--- a/library/headers.inc.php
+++ b/library/headers.inc.php
@@ -19,8 +19,9 @@
  */
 
 ?>
-<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
 <link rel="stylesheet" type="text/css" href=<?php echo $web_root; ?>/interface/themes/style.php?pc=<?php echo str_replace("#", "",$GLOBALS['primary_color']);?>&pfontcolor=<?php echo str_replace("#", "", $GLOBALS['primary_font_color']);?>&sc=<?php echo str_replace("#", "", $GLOBALS['secondary_color']);?>&sfontcolor=<?php echo str_replace("#", "",$GLOBALS['secondary_font_color']);?>>
+<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
+
 <?php
 
     function include_js_library($path)


### PR DESCRIPTION
Fixes #1314 

_Updated below_

![image](https://user-images.githubusercontent.com/6632800/49341836-e2547a00-f64a-11e8-81b9-1bee47ed92db.png)



