### PR TITLE
Fix #1329: Backup Title Not Displaying Correctly

### DIFF
--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -163,7 +163,7 @@ if ($form_step == 0) {
    echo "  <td>" . xl('Create Eventlog Backup') . "</td>\n";
    echo " </tr>\n";
    echo " <tr>\n";
-   echo "  <td></td><td class='text'><b>" . xl('Note')."</b>&nbsp;" . xl('Please refer to').'&nbsp;README-Log-Backup.txt&nbsp;'.xl('file in the Documentation directory to learn how to automate the process of creating log backups') . "</td>\n";
+   echo "  <td></td><td class='text'><strong>" . xl('Note').":</strong>&nbsp;" . xl('Please refer to').'&nbsp;README-Log-Backup.txt&nbsp;'.xl('file in the Documentation directory to learn how to automate the process of creating log backups') . "</td>\n";
    echo " </tr>\n";
   echo "</table>\n";
 }


### PR DESCRIPTION
Fixes #1329 

<b> tag was directing the title to become "Note" instead of "Backup", so I used the strong tag instead.

![image](https://user-images.githubusercontent.com/41968151/49485116-3acc7880-f7ff-11e8-81e6-8e21eeb8727e.png)
