### PR TITLE
Fixing Unknown title for PDFs

### DIFF
--- a/interface/patient_file/addr_label.php
+++ b/interface/patient_file/addr_label.php
@@ -101,6 +101,11 @@ $xt +=$xt;
 $pdf->TextWithRotation($x + $xt, $y + $yt, $text3, $angle);
 $xt +=$xt;
 
-
-$pdf->Output();
+$output = $pdf->Output('','S');
+$output = base64_encode($output);
 ?>
+
+<title>Address Label</title>
+<body style="margin: 0">
+    <embed src="data:application/pdf;base64,<?php echo $output ?>" type='application/pdf' style="position: fixed; width: 100%; height: 100%;">
+</body>

--- a/interface/patient_file/barcode_label.php
+++ b/interface/patient_file/barcode_label.php
@@ -142,5 +142,12 @@ Barcode::rotate(-$len / 2, ($data['height'] / 2) + $fontSize + $marge, $angle, $
 // -------------------------------------------------- //
  
 $pdf->TextWithRotation($x + $xt, $y + $yt, $data['hri'], $angle);
-$pdf->Output();
+
+$output = $pdf->Output('','S');
+$output = base64_encode($output);
 ?>
+
+<title>Barcode Label</title>
+<body style="margin: 0">
+    <embed src="data:application/pdf;base64,<?php echo $output ?>" type='application/pdf' style="position: fixed; width: 100%; height: 100%;">
+</body>

--- a/interface/patient_file/label.php
+++ b/interface/patient_file/label.php
@@ -75,5 +75,11 @@ for($i=1;$i<=$last;$i++) {
 	$pdf->Add_Label($text);
 }
 
-$pdf->Output();
+$output = $pdf->Output('','S');
+$output = base64_encode($output);
 ?>
+
+<title>Chart Label</title>
+<body style="margin: 0">
+    <embed src="data:application/pdf;base64,<?php echo $output ?>" type='application/pdf' style="position: fixed; width: 100%; height: 100%;">
+</body>


### PR DESCRIPTION
PDFs do not display titles as the pages are not stored with titles in. To add labels to PDF files, a structure similar to the committed changes must be employed. I was tempted to change this for ALL PDF files but was not sure how necessary this would be as they may not all be iframes. I am awaiting for @Trodrige 's view on this. 

Fixes #1336 