### PR TITLE
Fixes #1341 - Turned Button Texts to White

### DIFF
--- a/interface/themes/style_light.css
+++ b/interface/themes/style_light.css
@@ -693,7 +693,7 @@ tr.odd, td.even {
   padding-right: 10px;
   /* sliding doors padding */
   text-decoration: none;
-  color: #101e34 !important;
+  color: white !important;
   background-color: #5ac3ca;
   padding: 5px 12px 5px;
   border: none;

--- a/interface/themes/style_prism.css
+++ b/interface/themes/style_prism.css
@@ -675,7 +675,7 @@ tr.odd {
 }
 .css_button, button {
   background: #063f80;
-  color: #101e34  !important;
+  color: white  !important;
   display: inline-block;
   font-weight: 300;
   margin: 4px;


### PR DESCRIPTION
Previously the buttons on **New Encounter Form** were hardly visible because of their weird color combinations. I fixed them to white in Light and Prism theme.

Fixes #1341 

![screenshot from 2018-12-07 13-05-59](https://user-images.githubusercontent.com/16154204/49633867-f7515480-fa20-11e8-9539-1e631384ffca.png)
