### PR TITLE
Medical Issue End-date display

### DIFF
--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -238,7 +238,9 @@ foreach ($ISSUE_TYPES as $focustype => $focustitles) {
     echo " <tr class='$bgclass detail' $colorstyle>\n";
     echo "  <td style='text-align:left' class='$click_class' id='$rowid'>" . text($disptitle) . "</td>\n";
     echo "  <td>" . text(date(DateFormatRead(true), strtotime($row['begdate']))) . "&nbsp;</td>\n";
-    echo "  <td>" . text(date(DateFormatRead(true), strtotime($row['enddate']))) . "&nbsp;</td>\n";
+    if ($row['begdate'] == NULL){echo "  <td>" . text(date(DateFormatRead(true), strtotime($row['enddate']))) . "&nbsp;</td>\n";}
+    else{ echo "  <td>&nbsp;</td>\n";}
+   
     // both codetext and statusCompute have already been escaped above with htmlspecialchars)
     echo "  <td>" . $codetext . "</td>\n";
     echo "  <td>" . $statusCompute . "&nbsp;</td>\n";


### PR DESCRIPTION
In stats_full.php End date for an issue is displayed as a time when the value is NULL.  Looks goofy with fake negative 1969 date in there...this fixes it, especially when you add additional custom patient ISSUE types.