### PR TITLE
Fix: Table contents no longer overlap

### DIFF
--- a/modules/calendar/css/index.css
+++ b/modules/calendar/css/index.css
@@ -81,6 +81,10 @@ body {
   color: #000;
 }
 
+.fc-resource-cell {
+  word-wrap: break-word;
+}
+
 .tooltipevent {
   padding:5px;
   border-radius: 0.25em;


### PR DESCRIPTION
Fixes #1340.
Table elements no longer overlaps as word break in css is added.
<img width="177" alt="screen shot 2018-12-08 at 02 57 42" src="https://user-images.githubusercontent.com/28529491/49681294-3e7a2c80-fa97-11e8-82de-5ee1fd530ec9.png">
