### PR TITLE
Fix: View facility styling

### DIFF
--- a/interface/usergroup/assets/css/facility.css
+++ b/interface/usergroup/assets/css/facility.css
@@ -1,0 +1,31 @@
+#userinfotable {
+	width: 70%; min-width: 150px; max-width: 250px
+}
+
+.large_button{
+    margin-bottom: 5px;
+    float: right;
+}
+
+#userinfotable > tbody> tr> td {
+    padding-bottom: 10px;
+}
+
+#btnback{
+    margin-left: 30px;
+}
+
+.modaltitle {
+    margin: 10px 0px;
+}
+
+form {
+    margin-left: 0;
+}
+
+#modalbuttonrow {
+    position: absolute;
+    left: 10px;
+    bottom: 10px;
+    margin: 0;
+}

--- a/interface/usergroup/facility_user.php
+++ b/interface/usergroup/facility_user.php
@@ -73,6 +73,7 @@ if ( isset($_POST["mode"]) && $_POST["mode"] == "facility_user_id" && isset($_PO
 
       resolveFancyboxCompatibility();
 ?>
+<link rel="stylesheet" href="./assets/css/facility.css" type="text/css">
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/common.js"></script>
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/jquery-ui.js"></script>
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/jquery.easydrag.handler.beta2.js"></script>
@@ -130,7 +131,7 @@ for($i=0; $row=sqlFetchArray($l_res); $i++) {
        <table>
       <tr >
         <td><b><?php echo xlt('Facility Specific User Information'); ?></b></td>
-        <td><a href="usergroup_admin.php" class="css_button cp-misc" onclick="top.restoreSession()"><span><?php echo xlt('Back to Users'); ?></span></a>
+        <td><a id="btnback" href="usergroup_admin.php" class="css_button cp-misc" onclick="top.restoreSession()"><span><?php echo xlt('Back to Users'); ?></span></a>
         </td>
      </tr>
     </table>

--- a/interface/usergroup/facility_user_admin.php
+++ b/interface/usergroup/facility_user_admin.php
@@ -39,6 +39,7 @@ require_once("../globals.php");
 require_once("$srcdir/sql.inc");
 require_once("$srcdir/formdata.inc.php");
 require_once("$srcdir/options.inc.php");
+require_once("$srcdir/headers.inc.php");
 require_once("$srcdir/acl.inc");
 
 // Ensure authorized
@@ -57,6 +58,7 @@ if (!isset($_GET["user_id"]) || !isset($_GET["fac_id"])) {
 <head>
 
 <link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
+<link rel="stylesheet" href="./assets/css/facility.css" type="text/css">
 <link rel="stylesheet" type="text/css" href="../../library/js/fancybox/jquery.fancybox-1.2.6.css" media="screen" />
 <script type="text/javascript" src="../../library/dialog.js"></script>
 <script type="text/javascript" src="../../library/js/jquery.1.3.2.js"></script>
@@ -66,7 +68,9 @@ if (!isset($_GET["user_id"]) || !isset($_GET["fac_id"])) {
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/jquery.easydrag.handler.beta2.js"></script>
 <script type="text/javascript" src="../../library/textformat.js"></script>
 <script type="text/javascript" src="../../library/dynarch_calendar.js"></script>
-<?php include_once("{$GLOBALS['srcdir']}/dynarch_calendar_en.inc.php"); ?>
+<?php include_once("{$GLOBALS['srcdir']}/dynarch_calendar_en.inc.php"); 
+        call_required_libraries(array("bootstrap"));
+        ?>
 <script type="text/javascript" src="../../library/dynarch_calendar_setup.js"></script>
 <script language="JavaScript">
 
@@ -123,27 +127,15 @@ for($i=0; $row=sqlFetchArray($l_res); $i++) {
 }
 ?>
 
-<table>
-    <tr>
-        <td>
-        <span class="title"><?php echo xlt('Edit Facility Specific User Information'); ?></span>&nbsp;&nbsp;&nbsp;</td><td>
-        <a class="css_button large_button" name='form_save' id='form_save' onclick='submitform()' href='#' >
-            <span class='css_button_span large_button_span'><?php echo xlt('Save');?></span>
-        </a>
-        <a class="css_button large_button" id='cancel' href='#'>
-            <span class='css_button_span large_button_span'><?php echo xlt('Cancel');?></span>
-        </a>
-     </td>
-  </tr>
-</table>
-
+<h3 class="modaltitle"><?php echo xlt('Edit Facility Specific User Information'); ?></h3>
+<br/>
 <form name='medicare' method='post' action="facility_user.php" target="_parent">
     <input type=hidden name=mode value="facility_user_id">
     <input type=hidden name=user_id value="<?php echo attr($_GET["user_id"]);?>">
     <input type=hidden name=fac_id value="<?php echo attr($_GET["fac_id"]);?>">
     <?php $iter = sqlQuery("select * from facility_user_ids where id=?", array($my_id)); ?>
 
-<table border=0 cellpadding=0 cellspacing=0>
+<table id="userinfotable" border=0 cellpadding=0 cellspacing=0>
 <tr>
     <td>
         <span class=text><?php echo xlt('User'); ?>: </span>
@@ -178,7 +170,16 @@ for($i=0; $row=sqlFetchArray($l_res); $i++) {
 <?php } ?>
 
 </table>
+    <div class="row" id="modalbuttonrow">
+        <a class="btn btn-success" name='form_save' id='form_save' onclick='submitform()' href='#' >
+        <span class=''><?php echo xlt('Save');?></span>
+        </a>
+        <a class="btn btn-danger" id='cancel' href='#'>
+            <span class=''><?php echo xlt('Cancel');?></span>
+        </a>
+    </div>
 </form>
+
 
 <!-- include support for the list-add selectbox feature -->
 <?php include $GLOBALS['fileroot'] . "/library/options_listadd.inc"; ?>


### PR DESCRIPTION
**Link**: Admin->User->View Facility->’Click on user’s name’

**Work**: - add some space between “.... Information” and “Back to users” button
-Separate “Save” and “Cancel” buttons
Space between fields`
Bring fields closer to their labels.

**FIXED:**
- add some space between “.... Information” and “Back to users” button
- Separate “Save” and “Cancel” buttons
- Space between fields
- Bring fields closer to their labels.

**From this**
<img width="540" alt="screen shot 2018-12-09 at 00 07 41" src="https://user-images.githubusercontent.com/28529491/49691983-7d1af000-fb46-11e8-8b2a-fbedda18bbc1.png">
<img width="566" alt="screen shot 2018-12-08 at 05 47 20" src="https://user-images.githubusercontent.com/28529491/49682509-41801780-faad-11e8-9cf3-1000bea9aeb5.png">

**To this:**
<img width="527" alt="screen shot 2018-12-09 at 00 00 06" src="https://user-images.githubusercontent.com/28529491/49691941-82c40600-fb45-11e8-9a5a-504eb7d5e305.png">

