### PR TITLE
Fixes #1352 - Language Select Field Too Small

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -195,7 +195,7 @@ include_once("$srcdir/headers.inc.php");
                                     <tr>
                                         <td><span class="text"><?php echo xlt('Language'); ?></span></td>
                                         <td>
-                                            <select class="entryfield" name=languageChoice size="1" style = "height : 28px">
+                                            <select class="entryfield" name=languageChoice size="1" style = "height : 34px">
                                                 <?php
                                                 echo "<option selected='selected' value='" . attr($defaultLangID) . "'>" . xlt('Default') . " - " . xlt($defaultLangName) . "</option>\n";
                                                 foreach ($result3 as $iter) {


### PR DESCRIPTION
Fixes #1352 
Changed Height of the select field to 34px from 28px

Before : 
![screenshot from 2018-12-08 16-50-55](https://user-images.githubusercontent.com/16154204/49685519-8c7c4800-fb0a-11e8-9b52-703c21fb2b03.png)

After : 
![screenshot from 2018-12-08 16-58-22](https://user-images.githubusercontent.com/16154204/49685521-93a35600-fb0a-11e8-85cb-86b28d87ed9d.png)
