### PR TITLE
UI Fix: Clinical Instructions Form Styling

### DIFF
--- a/interface/forms/clinical_instructions/new.php
+++ b/interface/forms/clinical_instructions/new.php
@@ -51,20 +51,19 @@ $check_res = $formid ? formFetch("form_clinical_instructions", $formid) : array(
         <?php call_required_libraries(['bootstrap']); ?>
     </head>
     <body class="body_top">
-        <h2><?php echo xlt('Clinical Instructions Form'); ?></h2>
-        <h3><?php echo xlt('Instructions').':'; ?></h3>
+        <center>
+            <div class='title'><h2><?php echo xlt('Clinical Instructions Form'); ?></h2></div>
+            <h3><?php echo xlt('Instructions').':'; ?></h3>
 
-        <!-- Begin form -->
-        <?php echo "<form method='post' name='my_form' " . "action='$rootdir/forms/clinical_instructions/save.php?id=" . attr($formid) . "'>\n"; ?>
-            <div class="container" style="width: 500px; float: left;">
-                <textarea class="form-control" name="instruction" id ="instruction" rows=3>
-                    <?php echo text($check_res['instruction']); ?>
-                </textarea>
-                <br/>
-                <input type='submit' value='<?php echo xla('Save'); ?>' class="button-css cp-submit" style="float: right">&nbsp;
-            </div>
-
-        </form>
+            <!-- Begin form -->
+            <?php echo "<form method='post' name='my_form' " . "action='$rootdir/forms/clinical_instructions/save.php?id=" . attr($formid) . "'>\n"; ?>
+                <div class='form-group'>
+                    <textarea class="form-control" name="instruction" id ="instruction" rows=3 style='resize: vertical;'><?php echo text($check_res['instruction']); ?></textarea>
+                    <br/>
+                    <input class='btn btn-primary' type='submit' value='<?php echo xla('Save'); ?>' class="button-css cp-submit" style="float: right">&nbsp;
+                </div>
+            </form>
+        </center>
     <!-- formFooter() closes body and html tags -->
     <?php
     formFooter();


### PR DESCRIPTION
**GCI: Task 4 in EHR UI Grab Bag**

## Description
Link: Patient->Visits->Current->Clinical->Clinical instructions
Work: - Centralize the form. -Change tab title from “New encounter” to “Clinical instructions”

## Before
![image](https://user-images.githubusercontent.com/41968151/49691991-7b383900-fb14-11e8-90f5-ddc0a7128657.png)

## After
![image](https://user-images.githubusercontent.com/41968151/49692522-403d0200-fb22-11e8-8356-2d11a5e9a303.png)