### PR TITLE
Style: Patient->Visits->Current->Clinical

### DIFF
--- a/interface/forms/dictation/new.php
+++ b/interface/forms/dictation/new.php
@@ -13,13 +13,13 @@ $returnurl = 'encounter_top.php';
 <html>
 	<head>
 		<?php html_header_show();?>
-		<?php call_required_libraries(['bootstrap', 'jquery-min-1-9-1']); ?>
+		<?php call_required_libraries(['bootstrap', 'jquery-min-1-9-1', 'font-awesome']); ?>
 		<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
 	</head>
 	<body class="body_top">
-		<span class="title" style="display: none;"><?php echo xlt('Speech Dictation'); ?></span><br><br>
-		<h2><?php echo xlt('Speech Dictation'); ?></h2>
 		<form method=post action="<?php echo $rootdir;?>/forms/dictation/save.php?mode=new" name="my_form">
+			<a href="javascript:history.back()"><h4><i class="fa fa-chevron-left" id="backbutton" aria-hidden="true"></i> Back</h4></a>
+			<h4 class="title"><strong><?php echo xlt('Speech Dictation'); ?></strong></h4>
 			<table class="table table-bordered table-hover table-condensed">
 				<tr>
 					<td align="left"><?php echo xlt('Dictation:'); ?></td>
@@ -36,11 +36,11 @@ $returnurl = 'encounter_top.php';
 			</table>
 			<div>
 				<!-- Save/Cancel buttons -->
-				<a role="button" href="javascript:top.restoreSession(); document.my_form.submit();" class="link_submit cp-submit">
+				<a role="button" href="javascript:top.restoreSession(); document.my_form.submit();" class="btn btn-success">
 					<?php echo xlt('Save'); ?>
 				</a>
-				<a class="deleter cp-negative" role="button" href="<?php echo "$rootdir/patient_file/encounter/$returnurl";?>" class="link" onclick="top.restoreSession()">
-					<?php echo xlt('Don\'t Save'); ?>
+				<a class="deleter btn btn-danger" role="button" href="<?php echo "$rootdir/patient_file/encounter/$returnurl";?>" onclick="top.restoreSession()">
+					<?php echo xlt('Cancel'); ?>
 				</a>
 			</div>
 		</form>

--- a/interface/forms/reviewofs/new.php
+++ b/interface/forms/reviewofs/new.php
@@ -11,7 +11,7 @@ $returnurl = 'encounter_top.php';
 		<?php html_header_show();?>
 		<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
 		<!-- Get Bootstrap and jQuery (required for bootstrap) -->
-		<?php call_required_libraries(array('bootstrap', 'jquery-min-1-9-1')); ?>
+		<?php call_required_libraries(array('bootstrap', 'jquery-min-1-9-1', 'font-awesome')); ?>
 	    <script type="text/javascript">
 	      // Resizes the panels to be the height of the largest panel
 	      function resizePanel() {
@@ -25,179 +25,200 @@ $returnurl = 'encounter_top.php';
 	<body class="body_top" onresize = "resizePanel()">
 		<form method=post action="<?php echo $rootdir;?>/forms/reviewofs/save.php?mode=new"
 		 name="my_form" onsubmit="return top.restoreSession()">
-			<span class="title"><?php xl('Review of Systems Checks','e'); ?></span><br><br>
+			<a href="javascript:history.back()"><h4><i class="fa fa-chevron-left" id="backbutton" aria-hidden="true"></i> Back</h4></a>
+			<div class="col-sm-12"><h4 class="title"><strong><?php xl('Review of Systems Checks','e'); ?></strong></h4></div>
 
-			<div class="col-sm-6 col-md-2 panel panel-primary">
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('General','e'); ?></h3>
+			<div class="col-sm-6 col-md-2">
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('General','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='fever'  ><span class=text><?php xl('Fever','e'); ?></span><br>
+						<input type=checkbox name='chills'  ><span class=text><?php xl('Chills','e'); ?></span><br>
+						<input type=checkbox name='night_sweats'  ><span class=text><?php xl('Night Sweats','e'); ?></span><br>
+						<input type=checkbox name='weight_loss'  ><span class=text><?php xl('Weight Loss','e'); ?></span><br>
+						<input type=checkbox name='poor_appetite'  ><span class=text><?php xl('Poor Appetite','e'); ?></span><br>
+						<input type=checkbox name='insomnia'  ><span class=text><?php xl('Insomnia','e'); ?></span><br>
+						<input type=checkbox name='fatigued'  ><span class=text><?php xl('Fatigued','e'); ?></span><br>
+						<input type=checkbox name='depressed'  ><span class=text><?php xl('Depressed','e'); ?></span><br>
+						<input type=checkbox name='hyperactive'  ><span class=text><?php xl('Hyperactive','e'); ?></span><br>
+						<input type=checkbox name='exposure_to_foreign_countries'  ><span class=text><?php xl('Exposure to Foreign Countries','e'); ?></span>
+					</div>
 				</div>
-				<div class="panel-body">
-					<input type=checkbox name='fever'  ><span class=text><?php xl('Fever','e'); ?></span><br>
-					<input type=checkbox name='chills'  ><span class=text><?php xl('Chills','e'); ?></span><br>
-					<input type=checkbox name='night_sweats'  ><span class=text><?php xl('Night Sweats','e'); ?></span><br>
-					<input type=checkbox name='weight_loss'  ><span class=text><?php xl('Weight Loss','e'); ?></span><br>
-					<input type=checkbox name='poor_appetite'  ><span class=text><?php xl('Poor Appetite','e'); ?></span><br>
-					<input type=checkbox name='insomnia'  ><span class=text><?php xl('Insomnia','e'); ?></span><br>
-					<input type=checkbox name='fatigued'  ><span class=text><?php xl('Fatigued','e'); ?></span><br>
-					<input type=checkbox name='depressed'  ><span class=text><?php xl('Depressed','e'); ?></span><br>
-					<input type=checkbox name='hyperactive'  ><span class=text><?php xl('Hyperactive','e'); ?></span><br>
-					<input type=checkbox name='exposure_to_foreign_countries'  ><span class=text><?php xl('Exposure to Foreign Countries','e'); ?></span>
-				</div>
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Skin','e'); ?></h3>
-				</div>
-				<div class="panel-body">
-					<input type=checkbox name='rashes'  ><span class=text><?php xl('Rashes','e'); ?></span><br>
-					<input type=checkbox name='infections'  ><span class=text><?php xl('Infections','e'); ?></span><br>
-					<input type=checkbox name='ulcerations'  ><span class=text><?php xl('Ulcerations','e'); ?></span><br>
-					<input type=checkbox name='pemphigus'  ><span class=text><?php xl('Pemphigus','e'); ?></span><br>
-					<input type=checkbox name='herpes'  ><span class=text><?php xl('Herpes','e'); ?></span>
-				</div>
-			</div>
-			<div class="col-sm-6 col-md-2 panel panel-primary">
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('HEENT','e'); ?></h3>
-				</div>
-				<div class="panel-body">
-					<input type=checkbox name='cataracts'  ><span class=text><?php xl('Cataracts','e'); ?></span><br>
-					<input type=checkbox name='cataract_surgery'  ><span class=text><?php xl('Cataract Surgery','e'); ?></span><br>
-					<input type=checkbox name='glaucoma'  ><span class=text><?php xl('Glaucoma','e'); ?></span><br>
-					<input type=checkbox name='double_vision'  ><span class=text><?php xl('Double Vision','e'); ?></span><br>
-					<input type=checkbox name='blurred_vision'  ><span class=text><?php xl('Blurred Vision','e'); ?></span><br>
-					<input type=checkbox name='poor_hearing'  ><span class=text><?php xl('Poor Hearing','e'); ?></span><br>
-					<input type=checkbox name='headaches'  ><span class=text><?php xl('Headaches','e'); ?></span><br>
-					<input type=checkbox name='ringing_in_ears'  ><span class=text><?php xl('Ringing in Ears','e'); ?></span><br>
-					<input type=checkbox name='bloody_nose'  ><span class=text><?php xl('Bloody Nose','e'); ?></span><br>
-					<input type=checkbox name='sinusitis'  ><span class=text><?php xl('Sinusitis','e'); ?></span><br>
-					<input type=checkbox name='sinus_surgery'  ><span class=text><?php xl('Sinus Surgery','e'); ?></span><br>
-					<input type=checkbox name='dry_mouth'  ><span class=text><?php xl('Dry Mouth','e'); ?></span><br>
-					<input type=checkbox name='strep_throat'  ><span class=text><?php xl('Strep Throat','e'); ?></span><br>
-					<input type=checkbox name='tonsillectomy'  ><span class=text><?php xl('Tonsillectomy','e'); ?></span><br>
-					<input type=checkbox name='swollen_lymph_nodes'  ><span class=text><?php xl('Swollen Lymph Nodes','e'); ?></span><br>
-					<input type=checkbox name='throat_cancer'  ><span class=text><?php xl('Throat Cancer','e'); ?></span><br>
-					<input type=checkbox name='throat_cancer_surgery'  ><span class=text><?php xl('Throat Cancer Surgery','e'); ?></span>
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Skin','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='rashes'  ><span class=text><?php xl('Rashes','e'); ?></span><br>
+						<input type=checkbox name='infections'  ><span class=text><?php xl('Infections','e'); ?></span><br>
+						<input type=checkbox name='ulcerations'  ><span class=text><?php xl('Ulcerations','e'); ?></span><br>
+						<input type=checkbox name='pemphigus'  ><span class=text><?php xl('Pemphigus','e'); ?></span><br>
+						<input type=checkbox name='herpes'  ><span class=text><?php xl('Herpes','e'); ?></span>
+					</div>
 				</div>
 			</div>
-			<div class="col-sm-6 col-md-2 panel panel-primary">
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Cardiovascular','e'); ?></h3>
-				</div>
-				<div class="panel-body">
-					<input type=checkbox name='heart_attack'  ><span class=text><?php xl('Heart Attack','e'); ?></span><br>
-					<input type=checkbox name='irregular_heart_beat'  ><span class=text><?php xl('Irregular Heart Beat','e'); ?></span><br>
-					<input type=checkbox name='chest_pains'  ><span class=text><?php xl('Chest Pains','e'); ?></span><br>
-					<input type=checkbox name='shortness_of_breath'  ><span class=text><?php xl('Shortness of Breath','e'); ?></span><br>
-					<input type=checkbox name='high_blood_pressure'  ><span class=text><?php xl('High Blood Pressure','e'); ?></span><br>
-					<input type=checkbox name='heart_failure'  ><span class=text><?php xl('Heart Failure','e'); ?></span><br>
-					<input type=checkbox name='poor_circulation'  ><span class=text><?php xl('Poor Circulation','e'); ?></span><br>
-					<input type=checkbox name='vascular_surgery'  ><span class=text><?php xl('Vascular Surgery','e'); ?></span><br>
-					<input type=checkbox name='cardiac_catheterization'  ><span class=text><?php xl('Cardiac Catheterization','e'); ?></span><br>
-					<input type=checkbox name='coronary_artery_bypass'  ><span class=text><?php xl('Coronary Artery Bypass','e'); ?></span><br>
-					<input type=checkbox name='heart_transplant'  ><span class=text><?php xl('Heart Transplant','e'); ?></span><br>
-					<input type=checkbox name='stress_test'  ><span class=text><?php xl('Stress Test','e'); ?></span>
-				</div>
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Endocrine','e'); ?></h3>
-				</div>
-				<div class="panel-body">
-					<input type=checkbox name='insulin_dependent_diabetes'  ><span class=text><?php xl('Insulin Dependent Diabetes','e'); ?></span><br>
-					<input type=checkbox name='noninsulin_dependent_diabetes'  ><span class=text><?php xl('Non-Insulin Dependent Diabetes','e'); ?></span><br>
-					<input type=checkbox name='hypothyroidism'  ><span class=text><?php xl('Hypothyroidism','e'); ?></span><br>
-					<input type=checkbox name='hyperthyroidism'  ><span class=text><?php xl('Hyperthyroidism','e'); ?></span><br>
-					<input type=checkbox name='cushing_syndrom'  ><span class=text><?php xl('Cushing Syndrome','e'); ?></span><br>
-					<input type=checkbox name='addison_syndrom'  ><span class=text><?php xl('Addison Syndrome','e'); ?></span><br>
+			<div class="col-sm-6 col-md-2">
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('HEENT','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='cataracts'  ><span class=text><?php xl('Cataracts','e'); ?></span><br>
+						<input type=checkbox name='cataract_surgery'  ><span class=text><?php xl('Cataract Surgery','e'); ?></span><br>
+						<input type=checkbox name='glaucoma'  ><span class=text><?php xl('Glaucoma','e'); ?></span><br>
+						<input type=checkbox name='double_vision'  ><span class=text><?php xl('Double Vision','e'); ?></span><br>
+						<input type=checkbox name='blurred_vision'  ><span class=text><?php xl('Blurred Vision','e'); ?></span><br>
+						<input type=checkbox name='poor_hearing'  ><span class=text><?php xl('Poor Hearing','e'); ?></span><br>
+						<input type=checkbox name='headaches'  ><span class=text><?php xl('Headaches','e'); ?></span><br>
+						<input type=checkbox name='ringing_in_ears'  ><span class=text><?php xl('Ringing in Ears','e'); ?></span><br>
+						<input type=checkbox name='bloody_nose'  ><span class=text><?php xl('Bloody Nose','e'); ?></span><br>
+						<input type=checkbox name='sinusitis'  ><span class=text><?php xl('Sinusitis','e'); ?></span><br>
+						<input type=checkbox name='sinus_surgery'  ><span class=text><?php xl('Sinus Surgery','e'); ?></span><br>
+						<input type=checkbox name='dry_mouth'  ><span class=text><?php xl('Dry Mouth','e'); ?></span><br>
+						<input type=checkbox name='strep_throat'  ><span class=text><?php xl('Strep Throat','e'); ?></span><br>
+						<input type=checkbox name='tonsillectomy'  ><span class=text><?php xl('Tonsillectomy','e'); ?></span><br>
+						<input type=checkbox name='swollen_lymph_nodes'  ><span class=text><?php xl('Swollen Lymph Nodes','e'); ?></span><br>
+						<input type=checkbox name='throat_cancer'  ><span class=text><?php xl('Throat Cancer','e'); ?></span><br>
+						<input type=checkbox name='throat_cancer_surgery'  ><span class=text><?php xl('Throat Cancer Surgery','e'); ?></span>
+					</div>
 				</div>
 			</div>
-			<div id="largest-panel" class="col-sm-6 col-md-2 panel panel-primary">
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Pulmonary','e'); ?></h3>
+			<div class="col-sm-6 col-md-2">
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Cardiovascular','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='heart_attack'  ><span class=text><?php xl('Heart Attack','e'); ?></span><br>
+						<input type=checkbox name='irregular_heart_beat'  ><span class=text><?php xl('Irregular Heart Beat','e'); ?></span><br>
+						<input type=checkbox name='chest_pains'  ><span class=text><?php xl('Chest Pains','e'); ?></span><br>
+						<input type=checkbox name='shortness_of_breath'  ><span class=text><?php xl('Shortness of Breath','e'); ?></span><br>
+						<input type=checkbox name='high_blood_pressure'  ><span class=text><?php xl('High Blood Pressure','e'); ?></span><br>
+						<input type=checkbox name='heart_failure'  ><span class=text><?php xl('Heart Failure','e'); ?></span><br>
+						<input type=checkbox name='poor_circulation'  ><span class=text><?php xl('Poor Circulation','e'); ?></span><br>
+						<input type=checkbox name='vascular_surgery'  ><span class=text><?php xl('Vascular Surgery','e'); ?></span><br>
+						<input type=checkbox name='cardiac_catheterization'  ><span class=text><?php xl('Cardiac Catheterization','e'); ?></span><br>
+						<input type=checkbox name='coronary_artery_bypass'  ><span class=text><?php xl('Coronary Artery Bypass','e'); ?></span><br>
+						<input type=checkbox name='heart_transplant'  ><span class=text><?php xl('Heart Transplant','e'); ?></span><br>
+						<input type=checkbox name='stress_test'  ><span class=text><?php xl('Stress Test','e'); ?></span>
+					</div>
 				</div>
-				<div class="panel-body">
-					<input type=checkbox name='emphysema'  ><span class=text><?php xl('Emphysema','e'); ?></span><br>
-					<input type=checkbox name='chronic_bronchitis'  ><span class=text><?php xl('Chronic Bronchitis','e'); ?></span><br>
-					<input type=checkbox name='interstitial_lung_disease'  ><span class=text><?php xl('Interstitial Lung Disease','e'); ?></span><br>
-					<input type=checkbox name='shortness_of_breath_2'  ><span class=text><?php xl('Shortness of Breath','e'); ?></span><br>
-					<input type=checkbox name='lung_cancer'  ><span class=text><?php xl('Lung Cancer','e'); ?></span><br>
-					<input type=checkbox name='lung_cancer_surgery'  ><span class=text><?php xl('Lung Cancer Surgery','e'); ?></span><br>
-					<input type=checkbox name='pheumothorax'  ><span class=text><?php xl('Pheumothorax','e'); ?></span>
-				</div>
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Genitourinary','e'); ?></h3>
-				</div>
-				<div class="panel-body">
-					<input type=checkbox name='kidney_failure'  ><span class=text><?php xl('Kidney Failure','e'); ?></span><br>
-					<input type=checkbox name='kidney_stones'  ><span class=text><?php xl('Kidney Stones','e'); ?></span><br>
-					<input type=checkbox name='kidney_cancer'  ><span class=text><?php xl('Kidney Cancer','e'); ?></span><br>
-					<input type=checkbox name='kidney_infections'  ><span class=text><?php xl('Kidney Infections','e'); ?></span><br>
-					<input type=checkbox name='bladder_infections'  ><span class=text><?php xl('Bladder Infections','e'); ?></span><br>
-					<input type=checkbox name='bladder_cancer'  ><span class=text><?php xl('Bladder Cancer','e'); ?></span><br>
-					<input type=checkbox name='prostate_problems'  ><span class=text><?php xl('Prostate Problems','e'); ?></span><br>
-					<input type=checkbox name='prostate_cancer'  ><span class=text><?php xl('Prostate Cancer','e'); ?></span><br>
-					<input type=checkbox name='kidney_transplant'  ><span class=text><?php xl('Kidney Transplant','e'); ?></span><br>
-					<input type=checkbox name='sexually_transmitted_disease'  ><span class=text><?php xl('Sexually Transmitted Disease','e'); ?></span><br>
-					<input type=checkbox name='burning_with_urination'  ><span class=text><?php xl('Burning with Urination','e'); ?></span><br>
-					<input type=checkbox name='discharge_from_urethra'  ><span class=text><?php xl('Discharge From Urethra','e'); ?></span><br>
-				</div>
-			</div>
-			<div class="col-sm-6 col-md-2 panel panel-primary">
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Gastrointestinal','e'); ?></h3>
-				</div>
-				<div class="panel-body">
-					<input type=checkbox name='stomach_pains'  ><span class=text><?php xl('Stomach Pains','e'); ?></span><br>
-					<input type=checkbox name='peptic_ulcer_disease'  ><span class=text><?php xl('Peptic Ulcer Disease','e'); ?></span><br>
-					<input type=checkbox name='gastritis'  ><span class=text><?php xl('Gastritis','e'); ?></span><br>
-					<input type=checkbox name='endoscopy'  ><span class=text><?php xl('Endoscopy','e'); ?></span><br>
-					<input type=checkbox name='polyps'  ><span class=text><?php xl('Polyps','e'); ?></span><br>
-					<input type=checkbox name='colonoscopy'  ><span class=text><?php xl('Colonoscopy','e'); ?></span><br>
-					<input type=checkbox name='colon_cancer'  ><span class=text><?php xl('Colon Cancer','e'); ?></span><br>
-					<input type=checkbox name='colon_cancer_surgery'  ><span class=text><?php xl('Colon Cancer Surgery','e'); ?></span><br>
-					<input type=checkbox name='ulcerative_colitis'  ><span class=text><?php xl('Ulcerative Colitis','e'); ?></span><br>
-					<input type=checkbox name='crohns_disease'  ><span class=text><?php xl('Crohn\'s Disease','e'); ?></span><br>
-					<input type=checkbox name='appendectomy'  ><span class=text><?php xl('Appendectomy','e'); ?></span><br>
-					<input type=checkbox name='divirticulitis'  ><span class=text><?php xl('Diverticulitis','e'); ?></span><br>
-					<input type=checkbox name='divirticulitis_surgery'  ><span class=text><?php xl('Diverticulitis Surgery','e'); ?></span><br>
-					<input type=checkbox name='gall_stones'  ><span class=text><?php xl('Gall Stones','e'); ?></span><br>
-					<input type=checkbox name='cholecystectomy'  ><span class=text><?php xl('Cholecystectomy','e'); ?></span><br>
-					<input type=checkbox name='hepatitis'  ><span class=text><?php xl('Hepatitis','e'); ?></span><br>
-					<input type=checkbox name='cirrhosis_of_the_liver'  ><span class=text><?php xl('Cirrhosis of the Liver','e'); ?></span><br>
-					<input type=checkbox name='splenectomy'  ><span class=text><?php xl('Splenectomy','e'); ?></span>
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Endocrine','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='insulin_dependent_diabetes'  ><span class=text><?php xl('Insulin Dependent Diabetes','e'); ?></span><br>
+						<input type=checkbox name='noninsulin_dependent_diabetes'  ><span class=text><?php xl('Non-Insulin Dependent Diabetes','e'); ?></span><br>
+						<input type=checkbox name='hypothyroidism'  ><span class=text><?php xl('Hypothyroidism','e'); ?></span><br>
+						<input type=checkbox name='hyperthyroidism'  ><span class=text><?php xl('Hyperthyroidism','e'); ?></span><br>
+						<input type=checkbox name='cushing_syndrom'  ><span class=text><?php xl('Cushing Syndrome','e'); ?></span><br>
+						<input type=checkbox name='addison_syndrom'  ><span class=text><?php xl('Addison Syndrome','e'); ?></span><br>
+					</div>
 				</div>
 			</div>
-			<div class="col-sm-6 col-md-2 panel panel-primary">
-				<div class="panel-heading">
-					<h3 class="panel-title"><?php xl('Musculoskeletal','e'); ?></h3>
+			<div class="col-sm-6 col-md-2">
+				<div id="largest-panel" class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Pulmonary','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='emphysema'  ><span class=text><?php xl('Emphysema','e'); ?></span><br>
+						<input type=checkbox name='chronic_bronchitis'  ><span class=text><?php xl('Chronic Bronchitis','e'); ?></span><br>
+						<input type=checkbox name='interstitial_lung_disease'  ><span class=text><?php xl('Interstitial Lung Disease','e'); ?></span><br>
+						<input type=checkbox name='shortness_of_breath_2'  ><span class=text><?php xl('Shortness of Breath','e'); ?></span><br>
+						<input type=checkbox name='lung_cancer'  ><span class=text><?php xl('Lung Cancer','e'); ?></span><br>
+						<input type=checkbox name='lung_cancer_surgery'  ><span class=text><?php xl('Lung Cancer Surgery','e'); ?></span><br>
+						<input type=checkbox name='pheumothorax'  ><span class=text><?php xl('Pheumothorax','e'); ?></span>
+					</div>
 				</div>
-				<div class="panel-body">
-					<input type=checkbox name='osetoarthritis'  ><span class=text><?php xl('Osetoarthritis','e'); ?></span><br>
-					<input type=checkbox name='rheumotoid_arthritis'  ><span class=text><?php xl('Rheumotoid Arthritis','e'); ?></span><br>
-					<input type=checkbox name='lupus'  ><span class=text><?php xl('Lupus','e'); ?></span><br>
-					<input type=checkbox name='ankylosing_sondlilitis'  ><span class=text><?php xl('Ankylosing Spondlilitis','e'); ?></span><br>
-					<input type=checkbox name='swollen_joints'  ><span class=text><?php xl('Swollen Joints','e'); ?></span><br>
-					<input type=checkbox name='stiff_joints'  ><span class=text><?php xl('Stiff Joints','e'); ?></span><br>
-					<input type=checkbox name='broken_bones'  ><span class=text><?php xl('Broken Bones','e'); ?></span><br>
-					<input type=checkbox name='neck_problems'  ><span class=text><?php xl('Neck Problems','e'); ?></span><br>
-					<input type=checkbox name='back_problems'  ><span class=text><?php xl('Back Problems','e'); ?></span><br>
-					<input type=checkbox name='back_surgery'  ><span class=text><?php xl('Back Surgery','e'); ?></span><br>
-					<input type=checkbox name='scoliosis'  ><span class=text><?php xl('Scoliosis','e'); ?></span><br>
-					<input type=checkbox name='herniated_disc'  ><span class=text><?php xl('Herniated Disc','e'); ?></span><br>
-					<input type=checkbox name='shoulder_problems'  ><span class=text><?php xl('Shoulder Problems','e'); ?></span><br>
-					<input type=checkbox name='elbow_problems'  ><span class=text><?php xl('Elbow Problems','e'); ?></span><br>
-					<input type=checkbox name='wrist_problems'  ><span class=text><?php xl('Wrist Problems','e'); ?></span><br>
-					<input type=checkbox name='hand_problems'  ><span class=text><?php xl('Hand Problems','e'); ?></span><br>
-					<input type=checkbox name='hip_problems'  ><span class=text><?php xl('Hip Problems','e'); ?></span><br>
-					<input type=checkbox name='knee_problems'  ><span class=text><?php xl('Knee Problems','e'); ?></span><br>
-					<input type=checkbox name='ankle_problems'  ><span class=text><?php xl('Ankle Problems','e'); ?></span><br>
-					<input type=checkbox name='foot_problems'  ><span class=text><?php xl('Foot Problems','e'); ?></span>
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Genitourinary','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='kidney_failure'  ><span class=text><?php xl('Kidney Failure','e'); ?></span><br>
+						<input type=checkbox name='kidney_stones'  ><span class=text><?php xl('Kidney Stones','e'); ?></span><br>
+						<input type=checkbox name='kidney_cancer'  ><span class=text><?php xl('Kidney Cancer','e'); ?></span><br>
+						<input type=checkbox name='kidney_infections'  ><span class=text><?php xl('Kidney Infections','e'); ?></span><br>
+						<input type=checkbox name='bladder_infections'  ><span class=text><?php xl('Bladder Infections','e'); ?></span><br>
+						<input type=checkbox name='bladder_cancer'  ><span class=text><?php xl('Bladder Cancer','e'); ?></span><br>
+						<input type=checkbox name='prostate_problems'  ><span class=text><?php xl('Prostate Problems','e'); ?></span><br>
+						<input type=checkbox name='prostate_cancer'  ><span class=text><?php xl('Prostate Cancer','e'); ?></span><br>
+						<input type=checkbox name='kidney_transplant'  ><span class=text><?php xl('Kidney Transplant','e'); ?></span><br>
+						<input type=checkbox name='sexually_transmitted_disease'  ><span class=text><?php xl('Sexually Transmitted Disease','e'); ?></span><br>
+						<input type=checkbox name='burning_with_urination'  ><span class=text><?php xl('Burning with Urination','e'); ?></span><br>
+						<input type=checkbox name='discharge_from_urethra'  ><span class=text><?php xl('Discharge From Urethra','e'); ?></span><br>
+					</div>
 				</div>
 			</div>
-			<h4><?php xl('Additional Notes: ','e'); ?></h4>
-			<textarea class="form-control" style="width: auto;" cols=40 rows=8 wrap=virtual name="additional_notes"></textarea><br>
-			<br>
-			<div>
-				<!-- Save/Cancel buttons -->
-				<input type="submit" id="save" class='cp-submit' value="<?php echo xla('Save'); ?>"> &nbsp;
-				<input type="button" id="dontsave" class="deleter cp-negative" value="<?php echo xla('Cancel'); ?>"> &nbsp;
+			<div class="col-sm-6 col-md-2">
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Gastrointestinal','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='stomach_pains'  ><span class=text><?php xl('Stomach Pains','e'); ?></span><br>
+						<input type=checkbox name='peptic_ulcer_disease'  ><span class=text><?php xl('Peptic Ulcer Disease','e'); ?></span><br>
+						<input type=checkbox name='gastritis'  ><span class=text><?php xl('Gastritis','e'); ?></span><br>
+						<input type=checkbox name='endoscopy'  ><span class=text><?php xl('Endoscopy','e'); ?></span><br>
+						<input type=checkbox name='polyps'  ><span class=text><?php xl('Polyps','e'); ?></span><br>
+						<input type=checkbox name='colonoscopy'  ><span class=text><?php xl('Colonoscopy','e'); ?></span><br>
+						<input type=checkbox name='colon_cancer'  ><span class=text><?php xl('Colon Cancer','e'); ?></span><br>
+						<input type=checkbox name='colon_cancer_surgery'  ><span class=text><?php xl('Colon Cancer Surgery','e'); ?></span><br>
+						<input type=checkbox name='ulcerative_colitis'  ><span class=text><?php xl('Ulcerative Colitis','e'); ?></span><br>
+						<input type=checkbox name='crohns_disease'  ><span class=text><?php xl('Crohn\'s Disease','e'); ?></span><br>
+						<input type=checkbox name='appendectomy'  ><span class=text><?php xl('Appendectomy','e'); ?></span><br>
+						<input type=checkbox name='divirticulitis'  ><span class=text><?php xl('Diverticulitis','e'); ?></span><br>
+						<input type=checkbox name='divirticulitis_surgery'  ><span class=text><?php xl('Diverticulitis Surgery','e'); ?></span><br>
+						<input type=checkbox name='gall_stones'  ><span class=text><?php xl('Gall Stones','e'); ?></span><br>
+						<input type=checkbox name='cholecystectomy'  ><span class=text><?php xl('Cholecystectomy','e'); ?></span><br>
+						<input type=checkbox name='hepatitis'  ><span class=text><?php xl('Hepatitis','e'); ?></span><br>
+						<input type=checkbox name='cirrhosis_of_the_liver'  ><span class=text><?php xl('Cirrhosis of the Liver','e'); ?></span><br>
+						<input type=checkbox name='splenectomy'  ><span class=text><?php xl('Splenectomy','e'); ?></span>
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-6 col-md-2">
+				<div class="panel panel-primary">
+					<div class="panel-heading">
+						<h3 class="panel-title"><?php xl('Musculoskeletal','e'); ?></h3>
+					</div>
+					<div class="panel-body">
+						<input type=checkbox name='osetoarthritis'  ><span class=text><?php xl('Osetoarthritis','e'); ?></span><br>
+						<input type=checkbox name='rheumotoid_arthritis'  ><span class=text><?php xl('Rheumotoid Arthritis','e'); ?></span><br>
+						<input type=checkbox name='lupus'  ><span class=text><?php xl('Lupus','e'); ?></span><br>
+						<input type=checkbox name='ankylosing_sondlilitis'  ><span class=text><?php xl('Ankylosing Spondlilitis','e'); ?></span><br>
+						<input type=checkbox name='swollen_joints'  ><span class=text><?php xl('Swollen Joints','e'); ?></span><br>
+						<input type=checkbox name='stiff_joints'  ><span class=text><?php xl('Stiff Joints','e'); ?></span><br>
+						<input type=checkbox name='broken_bones'  ><span class=text><?php xl('Broken Bones','e'); ?></span><br>
+						<input type=checkbox name='neck_problems'  ><span class=text><?php xl('Neck Problems','e'); ?></span><br>
+						<input type=checkbox name='back_problems'  ><span class=text><?php xl('Back Problems','e'); ?></span><br>
+						<input type=checkbox name='back_surgery'  ><span class=text><?php xl('Back Surgery','e'); ?></span><br>
+						<input type=checkbox name='scoliosis'  ><span class=text><?php xl('Scoliosis','e'); ?></span><br>
+						<input type=checkbox name='herniated_disc'  ><span class=text><?php xl('Herniated Disc','e'); ?></span><br>
+						<input type=checkbox name='shoulder_problems'  ><span class=text><?php xl('Shoulder Problems','e'); ?></span><br>
+						<input type=checkbox name='elbow_problems'  ><span class=text><?php xl('Elbow Problems','e'); ?></span><br>
+						<input type=checkbox name='wrist_problems'  ><span class=text><?php xl('Wrist Problems','e'); ?></span><br>
+						<input type=checkbox name='hand_problems'  ><span class=text><?php xl('Hand Problems','e'); ?></span><br>
+						<input type=checkbox name='hip_problems'  ><span class=text><?php xl('Hip Problems','e'); ?></span><br>
+						<input type=checkbox name='knee_problems'  ><span class=text><?php xl('Knee Problems','e'); ?></span><br>
+						<input type=checkbox name='ankle_problems'  ><span class=text><?php xl('Ankle Problems','e'); ?></span><br>
+						<input type=checkbox name='foot_problems'  ><span class=text><?php xl('Foot Problems','e'); ?></span>
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-12">
+				<h4><?php xl('Additional Notes: ','e'); ?></h4>
+				<textarea class="form-control" style="width: auto;" cols=40 rows=8 wrap=virtual name="additional_notes"></textarea><br>
+				<br>
+				<div>
+					<!-- Save/Cancel buttons -->
+					<input type="submit" id="save" class='btn btn-success' value="<?php echo xla('Save'); ?>"> &nbsp;
+					<input type="button" id="dontsave" class="deleter btn btn-danger" value="<?php echo xla('Cancel'); ?>"> &nbsp;
+				</div>
 			</div>
 		</form>
 <!-- Includes closing body and html tags -->

--- a/interface/forms/ros/templates/ros/general_new.php
+++ b/interface/forms/ros/templates/ros/general_new.php
@@ -1,11 +1,11 @@
 <?php
-  include_once("../../globals.php");
+  include_once("../../../../globals.php");
   include_once("$srcdir/api.inc");
   formHeader("Review of Systems");
 ?>
 <html>
   <head>
-    <?php call_required_libraries(['jquery-min-1-9-1', 'bootstrap']); ?>
+    <?php call_required_libraries(array('jquery-min-1-9-1', 'bootstrap', 'font-awesome')); ?>
     <script type="text/javascript">
       // Resizes the panels to be the height of the largest panel
       function resizePanel() {
@@ -26,1511 +26,1546 @@
   </head>
   <!-- Made each section panels, to organize and add Bootstrap -->
   <body onresize ="resizePanel()">
-    <h2><?php echo xlt('Review of Systems'); ?></h2>
     <form
       name="ros"
       method="post"
       action="<?php echo $this->form_action;?>/interface/forms/ros/save.php"
       onsubmit="return top.restoreSession()"
     >
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Constitutional");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Weight Change");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_weight_change() ){?>
-                <label><input type="radio" name="weight_change" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="weight_change" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <a href="javascript:history.back()"><h4><i class="fa fa-chevron-left" id="backbutton" aria-hidden="true"></i> Back</h4></a>
+      <div class="col-xs-12">
+      <h4 class="title"><strong><?php echo xlt('Review of Systems'); ?></strong></h4>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Constitutional");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Weakness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_weakness() ){?>
-                <label><input type="radio" name="weakness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="weakness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Fatigue");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_fatigue() ){?>
-                <label><input type="radio" name="fatigue" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="fatigue" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Anorexia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_anorexia() ){?>
-                <label><input type="radio" name="anorexia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="anorexia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Fever");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_fever() ){?>
-                <label><input type="radio" name="fever" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="fever" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Chills");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_chills() ){?>
-                <label><input type="radio" name="chills" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="chills" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Night Sweats");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_night_sweats() ){?>
-                <label><input type="radio" name="night_sweats" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="night_sweats" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Insomnia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_insomnia() ){?>
-                <label><input type="radio" name="insomnia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="insomnia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Irritability");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_irritability() ){?>
-                <label><input type="radio" name="irritability" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="irritability" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Heat or Cold");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_heat_or_cold() ){?>
-                <label><input type="radio" name="heat_or_cold" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="heat_or_cold" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Intolerance");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_intolerance() ){?>
-                <label><input type="radio" name="intolerance" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="intolerance" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Weight Change");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_weight_change() ){?>
+                  <label><input type="radio" name="weight_change" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="weight_change" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Weakness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_weakness() ){?>
+                  <label><input type="radio" name="weakness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="weakness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Fatigue");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_fatigue() ){?>
+                  <label><input type="radio" name="fatigue" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="fatigue" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Anorexia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_anorexia() ){?>
+                  <label><input type="radio" name="anorexia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="anorexia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Fever");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_fever() ){?>
+                  <label><input type="radio" name="fever" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="fever" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Chills");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_chills() ){?>
+                  <label><input type="radio" name="chills" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="chills" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Night Sweats");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_night_sweats() ){?>
+                  <label><input type="radio" name="night_sweats" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="night_sweats" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Insomnia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_insomnia() ){?>
+                  <label><input type="radio" name="insomnia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="insomnia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Irritability");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_irritability() ){?>
+                  <label><input type="radio" name="irritability" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="irritability" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Heat or Cold");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_heat_or_cold() ){?>
+                  <label><input type="radio" name="heat_or_cold" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="heat_or_cold" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Intolerance");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_intolerance() ){?>
+                  <label><input type="radio" name="intolerance" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="intolerance" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Eyes");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Change in Vision");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_change_in_vision() ){?>
-                <label><input type="radio" name="change_in_vision" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="change_in_vision" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Eyes");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Family History of Glaucoma");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_glaucoma_history() ){?>
-                <label><input type="radio" name="glaucoma_history" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="glaucoma_history" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Eye Pain");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_eye_pain() ){?>
-                <label><input type="radio" name="eye_pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="eye_pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Irritation");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_irritation() ){?>
-                <label><input type="radio" name="irritation" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="irritation" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Redness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_redness() ){?>
-                <label><input type="radio" name="redness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="redness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Excessive Tearing");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_excessive_tearing() ){?>
-                <label><input type="radio" name="excessive_tearing" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="excessive_tearing" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Double Vision");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_double_vision() ){?>
-                <label><input type="radio" name="double_vision" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="double_vision" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Blind Spots");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_blind_spots() ){?>
-                <label><input type="radio" name="blind_spots" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="blind_spots" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Photophobia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_photophobia() ){?>
-                <label><input type="radio" name="photophobia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="photophobia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-        </div>
-      </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Ears");?>, <?php echo xlt("Nose");?>, <?php echo xlt("Mouth");?>, <?php echo xlt("Throat");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Hearing Loss");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hearing_loss() ){?>
-                <label><input type="radio" name="hearing_loss" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hearing_loss" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Discharge");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_discharge() ){?>
-                <label><input type="radio" name="discharge" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="discharge" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Pain");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_pain() ){?>
-                <label><input type="radio" name="pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("Vertigo");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_vertigo() ){?>
-                <label><input type="radio" name="vertigo" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="vertigo" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Tinnitus");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_tinnitus() ){?>
-                <label><input type="radio" name="tinnitus" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="tinnitus" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Frequent Colds");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_frequent_colds() ){?>
-                <label><input type="radio" name="frequent_colds" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="frequent_colds" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Sore Throat");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_sore_throat() ){?>
-                <label><input type="radio" name="sore_throat" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="sore_throat" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Sinus Problems");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_sinus_problems() ){?>
-                <label><input type="radio" name="sinus_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="sinus_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Post Nasal Drip");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_post_nasal_drip() ){?>
-                <label><input type="radio" name="post_nasal_drip" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="post_nasal_drip" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>      
-            <?php echo xlt("Nosebleed");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_nosebleed() ){?>
-                <label><input type="radio" name="nosebleed" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="nosebleed" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Snoring");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_snoring() ){?>
-                <label><input type="radio" name="snoring" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="snoring" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Apnea");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_apnea() ){?>
-                <label><input type="radio" name="apnea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="apnea" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Change in Vision");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_change_in_vision() ){?>
+                  <label><input type="radio" name="change_in_vision" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="change_in_vision" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Family History of Glaucoma");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_glaucoma_history() ){?>
+                  <label><input type="radio" name="glaucoma_history" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="glaucoma_history" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Eye Pain");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_eye_pain() ){?>
+                  <label><input type="radio" name="eye_pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="eye_pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Irritation");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_irritation() ){?>
+                  <label><input type="radio" name="irritation" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="irritation" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Redness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_redness() ){?>
+                  <label><input type="radio" name="redness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="redness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Excessive Tearing");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_excessive_tearing() ){?>
+                  <label><input type="radio" name="excessive_tearing" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="excessive_tearing" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Double Vision");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_double_vision() ){?>
+                  <label><input type="radio" name="double_vision" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="double_vision" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Blind Spots");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_blind_spots() ){?>
+                  <label><input type="radio" name="blind_spots" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="blind_spots" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Photophobia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_photophobia() ){?>
+                  <label><input type="radio" name="photophobia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="photophobia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Breast");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Breast Mass");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_breast_mass() ){?>
-                <label><input type="radio" name="breast_mass" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="breast_mass" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Ears");?>, <?php echo xlt("Nose");?>, <?php echo xlt("Mouth");?>, <?php echo xlt("Throat");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Discharge");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_discharge() ){?>
-                <label><input type="radio" name="discharge" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="discharge" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Biopsy");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_biopsy() ){?>
-                <label><input type="radio" name="biopsy" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="biopsy" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Abnormal Mammogram");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_abnormal_mammogram() ){?>
-                <label><input type="radio" name="abnormal_mammogram" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="abnormal_mammogram" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-        </div>
-      </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Respiratory");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Cough");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_cough() ){?>
-                <label><input type="radio" name="cough" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="cough" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Sputum");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_sputum() ){?>
-                <label><input type="radio" name="sputum" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="sputum" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Shortness of Breath");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_shortness_of_breath() ){?>
-                <label><input type="radio" name="shortness_of_breath" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="shortness_of_breath" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Wheezing");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_wheezing() ){?>
-                <label><input type="radio" name="wheezing" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="wheezing" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Hemoptysis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hemoptsyis() ){?>
-                <label><input type="radio" name="hemoptsyis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hemoptsyis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Asthma");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_asthma() ){?>
-                <label><input type="radio" name="asthma" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="asthma" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("COPD");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_copd() ){?>
-                <label><input type="radio" name="copd" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="copd" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>          
-          </div>
-        </div>
-      </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Cardiovascular");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Chest Pain");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_chest_pain() ){?>
-                <label><input type="radio" name="chest_pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="chest_pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("Palpitation");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_palpitation() ){?>
-                <label><input type="radio" name="palpitation" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="palpitation" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>           
-          </div>
-          <div>
-            <?php echo xlt("Syncope");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_syncope() ){?>
-                <label><input type="radio" name="syncope" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="syncope" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>           
-          </div>
-          <div>
-            <?php echo xlt("PND");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_pnd() ){?>
-                <label><input type="radio" name="pnd" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="pnd" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>           
-          </div>
-          <div>
-            <?php echo xlt("DOE");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_doe() ){?>
-                <label><input type="radio" name="doe" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="doe" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>           
-          </div>
-          <div>
-            <?php echo xlt("Orthopnea");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_orthopnea() ){?>
-                <label><input type="radio" name="orthopnea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="orthopnea" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>           
-          </div>
-          <!-- The get_peripheal function is mispelled -->
-          <div>
-            <?php echo xlt("Peripheral");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_peripheal() ){?>
-                <label><input type="radio" name="peripheal" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="peripheal" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("Edema");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_edema() ){?>
-                <label><input type="radio" name="edema" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="edema" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("Leg Pain/Cramping");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_legpain_cramping() ){?>
-                <label><input type="radio" name="legpain_cramping" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="legpain_cramping" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("History of Heart Murmur");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_history_murmur() ){?>
-                <label><input type="radio" name="history_murmur" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="history_murmur" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("Arryhthmia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_arryhthmia() ){?>
-                <label><input type="radio" name="arryhthmia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="arryhthmia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?> 
-          </div>
-          <div>
-            <?php echo xlt("Heart Problem");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_legpain_cramping() ){?>
-                <label><input type="radio" name="heart_problem" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="heart_problem" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Hearing Loss");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hearing_loss() ){?>
+                  <label><input type="radio" name="hearing_loss" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hearing_loss" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Discharge");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_discharge() ){?>
+                  <label><input type="radio" name="discharge" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="discharge" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Pain");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_pain() ){?>
+                  <label><input type="radio" name="pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("Vertigo");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_vertigo() ){?>
+                  <label><input type="radio" name="vertigo" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="vertigo" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Tinnitus");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_tinnitus() ){?>
+                  <label><input type="radio" name="tinnitus" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="tinnitus" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Frequent Colds");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_frequent_colds() ){?>
+                  <label><input type="radio" name="frequent_colds" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="frequent_colds" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Sore Throat");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_sore_throat() ){?>
+                  <label><input type="radio" name="sore_throat" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="sore_throat" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Sinus Problems");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_sinus_problems() ){?>
+                  <label><input type="radio" name="sinus_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="sinus_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Post Nasal Drip");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_post_nasal_drip() ){?>
+                  <label><input type="radio" name="post_nasal_drip" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="post_nasal_drip" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>      
+              <?php echo xlt("Nosebleed");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_nosebleed() ){?>
+                  <label><input type="radio" name="nosebleed" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="nosebleed" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Snoring");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_snoring() ){?>
+                  <label><input type="radio" name="snoring" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="snoring" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Apnea");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_apnea() ){?>
+                  <label><input type="radio" name="apnea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="apnea" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div id="largest-panel" class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Gastrointestinal");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Dysphagia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_dysphagia() ){?>
-                <label><input type="radio" name="dysphagia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="dysphagia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Breast");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Heartburn");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_heartburn() ){?>
-                <label><input type="radio" name="heartburn" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="heartburn" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Bloating");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_bloating() ){?>
-                <label><input type="radio" name="bloating" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="bloating" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Belching");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_belching() ){?>
-                <label><input type="radio" name="belching" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="belching" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Flatulence");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_flatulence() ){?>
-                <label><input type="radio" name="flatulence" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="flatulence" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Nausea");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_nausea() ){?>
-                <label><input type="radio" name="nausea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="nausea" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Vomiting");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_vomiting() ){?>
-                <label><input type="radio" name="vomiting" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="vomiting" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Hematemesis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hematemesis() ){?>
-                <label><input type="radio" name="hematemesis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hematemesis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Pain");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_pain() ){?>
-                <label><input type="radio" name="pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Food Intolerance");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_food_intolerance() ){?>
-                <label><input type="radio" name="food_intolerance" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="food_intolerance" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("H/O Hepatitis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hepatitis() ){?>
-                <label><input type="radio" name="hepatitis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hepatitis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Jaundice");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_jaundice() ){?>
-                <label><input type="radio" name="jaundice" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="jaundice" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Hematochezia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hematochezia() ){?>
-                <label><input type="radio" name="hematochezia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hematochezia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Changed Bowel");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_changed_bowel() ){?>
-                <label><input type="radio" name="changed_bowel" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="changed_bowel" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Diarrhea");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_diarrhea() ){?>
-                <label><input type="radio" name="diarrhea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="diarrhea" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Constipation");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_constipation() ){?>
-                <label><input type="radio" name="constipation" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="constipation" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Breast Mass");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_breast_mass() ){?>
+                  <label><input type="radio" name="breast_mass" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="breast_mass" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Discharge");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_discharge() ){?>
+                  <label><input type="radio" name="discharge" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="discharge" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Biopsy");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_biopsy() ){?>
+                  <label><input type="radio" name="biopsy" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="biopsy" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Abnormal Mammogram");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_abnormal_mammogram() ){?>
+                  <label><input type="radio" name="abnormal_mammogram" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="abnormal_mammogram" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Genitourinary General");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Polyuria");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_polyuria() ){?>
-                <label><input type="radio" name="polyuria" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="polyuria" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Respiratory");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Polydypsia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_polydypsia() ){?>
-                <label><input type="radio" name="polydypsia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="polydypsia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Dysuria");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_dysuria() ){?>
-                <label><input type="radio" name="dysuria" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="dysuria" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Hematuria");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hematuria() ){?>
-                <label><input type="radio" name="hematuria" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hematuria" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Frequency");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_frequency() ){?>
-                <label><input type="radio" name="frequency" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="frequency" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Urgency");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_urgency() ){?>
-                <label><input type="radio" name="urgency" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="urgency" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Incontinence");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_incontinence() ){?>
-                <label><input type="radio" name="incontinence" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="incontinence" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Renal Stones");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_renal_stones() ){?>
-                <label><input type="radio" name="renal_stones" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="renal_stones" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("UTIs");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_utis() ){?>
-                <label><input type="radio" name="utis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="utis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Cough");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_cough() ){?>
+                  <label><input type="radio" name="cough" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="cough" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Sputum");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_sputum() ){?>
+                  <label><input type="radio" name="sputum" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="sputum" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Shortness of Breath");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_shortness_of_breath() ){?>
+                  <label><input type="radio" name="shortness_of_breath" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="shortness_of_breath" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Wheezing");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_wheezing() ){?>
+                  <label><input type="radio" name="wheezing" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="wheezing" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Hemoptysis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hemoptsyis() ){?>
+                  <label><input type="radio" name="hemoptsyis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hemoptsyis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Asthma");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_asthma() ){?>
+                  <label><input type="radio" name="asthma" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="asthma" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("COPD");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_copd() ){?>
+                  <label><input type="radio" name="copd" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="copd" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>          
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Genitourinary Male");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Hesitancy");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hesitancy() ){?>
-                <label><input type="radio" name="hesitancy" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hesitancy" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Cardiovascular");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Dribbling");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_dribbling() ){?>
-                <label><input type="radio" name="dribbling" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="dribbling" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Stream");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_stream() ){?>
-                <label><input type="radio" name="stream" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="stream" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Nocturia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_nocturia() ){?>
-                <label><input type="radio" name="nocturia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="nocturia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Erections");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_erections() ){?>
-                <label><input type="radio" name="erections" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="erections" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Ejaculations");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_ejaculations() ){?>
-                <label><input type="radio" name="ejaculations" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="ejaculations" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-        </div>
-      </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Genitourinary Female");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Female G");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_g() ){?>
-                <label><input type="radio" name="g" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="g" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Female P");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_p() ){?>
-                <label><input type="radio" name="p" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="p" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Female AP");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_ap() ){?>
-                <label><input type="radio" name="ap" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="ap" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Female LC");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_lc() ){?>
-                <label><input type="radio" name="lc" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="lc" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <!-- The get_mearche function is mispelled -->
-          <div>
-            <?php echo xlt("Menarche");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_mearche() ){?>
-                <label><input type="radio" name="mearche" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="mearche" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Menopause");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_menopause() ){?>
-                <label><input type="radio" name="menopause" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="menopause" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("LMP");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_lmp() ){?>
-                <label><input type="radio" name="lmp" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="lmp" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Frequency");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_f_frequency() ){?>
-                <label><input type="radio" name="frequency" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="frequency" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Flow");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_f_flow() ){?>
-                <label><input type="radio" name="f_flow" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="f_flow" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Symptoms");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_f_symptoms() ){?>
-                <label><input type="radio" name="f_symptoms" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="f_symptoms" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Abnormal Hair Growth");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_abnormal_hair_growth() ){?>
-                <label><input type="radio" name="abnormal_hair_growth" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="abnormal_hair_growth" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("F/H Female Hirsutism/Striae");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_f_hirsutism() ){?>
-                <label><input type="radio" name="f_hirsutism" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="f_hirsutism" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Chest Pain");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_chest_pain() ){?>
+                  <label><input type="radio" name="chest_pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="chest_pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("Palpitation");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_palpitation() ){?>
+                  <label><input type="radio" name="palpitation" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="palpitation" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>           
+            </div>
+            <div>
+              <?php echo xlt("Syncope");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_syncope() ){?>
+                  <label><input type="radio" name="syncope" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="syncope" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>           
+            </div>
+            <div>
+              <?php echo xlt("PND");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_pnd() ){?>
+                  <label><input type="radio" name="pnd" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="pnd" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>           
+            </div>
+            <div>
+              <?php echo xlt("DOE");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_doe() ){?>
+                  <label><input type="radio" name="doe" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="doe" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>           
+            </div>
+            <div>
+              <?php echo xlt("Orthopnea");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_orthopnea() ){?>
+                  <label><input type="radio" name="orthopnea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="orthopnea" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>           
+            </div>
+            <!-- The get_peripheal function is mispelled -->
+            <div>
+              <?php echo xlt("Peripheral");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_peripheal() ){?>
+                  <label><input type="radio" name="peripheal" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="peripheal" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("Edema");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_edema() ){?>
+                  <label><input type="radio" name="edema" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="edema" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("Leg Pain/Cramping");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_legpain_cramping() ){?>
+                  <label><input type="radio" name="legpain_cramping" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="legpain_cramping" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("History of Heart Murmur");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_history_murmur() ){?>
+                  <label><input type="radio" name="history_murmur" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="history_murmur" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("Arryhthmia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_arryhthmia() ){?>
+                  <label><input type="radio" name="arryhthmia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="arryhthmia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?> 
+            </div>
+            <div>
+              <?php echo xlt("Heart Problem");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_legpain_cramping() ){?>
+                  <label><input type="radio" name="heart_problem" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="heart_problem" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Musculoskeletal");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Chronic Joint Pain");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_joint_pain() ){?>
-                <label><input type="radio" name="joint_pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="joint_pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div id="largest-panel" class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Gastrointestinal");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Swelling");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_swelling() ){?>
-                <label><input type="radio" name="swelling" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="swelling" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Redness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_redness() ){?>
-                <label><input type="radio" name="redness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="redness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Warm");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_m_warm() ){?>
-                <label><input type="radio" name="m_warm" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="m_warm" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Stiffness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_m_stiffness() ){?>
-                <label><input type="radio" name="m_stiffness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="m_stiffness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Muscle");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_muscle() ){?>
-                <label><input type="radio" name="muscle" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="muscle" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Aches");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_m_aches() ){?>
-                <label><input type="radio" name="m_aches" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="m_aches" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("FMS");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_fms() ){?>
-                <label><input type="radio" name="fms" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="fms" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Arthritis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_arthritis() ){?>
-                <label><input type="radio" name="arthritis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="arthritis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-        </div>
-      </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Neurologic");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("LOC");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_loc() ){?>
-                <label><input type="radio" name="loc" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="loc" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Seizures");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_seizures() ){?>
-                <label><input type="radio" name="seizures" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="seizures" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Stroke");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_stroke() ){?>
-                <label><input type="radio" name="stroke" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="stroke" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("TIA");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_tia() ){?>
-                <label><input type="radio" name="tia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="tia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Numbness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_n_numbness() ){?>
-                <label><input type="radio" name="n_numbness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="n_numbness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Weakness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_n_weakness() ){?>
-                <label><input type="radio" name="n_weakness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="n_weakness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Paralysis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_paralysis() ){?>
-                <label><input type="radio" name="paralysis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="paralysis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Intellectual Decline");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_intellectual_decline() ){?>
-                <label><input type="radio" name="intellectual_decline" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="intellectual_decline" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Memory Problems");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_memory_problems() ){?>
-                <label><input type="radio" name="memory_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="memory_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Dementia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_dementia() ){?>
-                <label><input type="radio" name="dementia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="dementia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Headache");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_n_headache() ){?>
-                <label><input type="radio" name="n_headache" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="n_headache" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Dysphagia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_dysphagia() ){?>
+                  <label><input type="radio" name="dysphagia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="dysphagia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Heartburn");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_heartburn() ){?>
+                  <label><input type="radio" name="heartburn" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="heartburn" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Bloating");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_bloating() ){?>
+                  <label><input type="radio" name="bloating" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="bloating" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Belching");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_belching() ){?>
+                  <label><input type="radio" name="belching" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="belching" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Flatulence");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_flatulence() ){?>
+                  <label><input type="radio" name="flatulence" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="flatulence" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Nausea");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_nausea() ){?>
+                  <label><input type="radio" name="nausea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="nausea" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Vomiting");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_vomiting() ){?>
+                  <label><input type="radio" name="vomiting" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="vomiting" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Hematemesis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hematemesis() ){?>
+                  <label><input type="radio" name="hematemesis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hematemesis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Pain");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_pain() ){?>
+                  <label><input type="radio" name="pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Food Intolerance");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_food_intolerance() ){?>
+                  <label><input type="radio" name="food_intolerance" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="food_intolerance" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("H/O Hepatitis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hepatitis() ){?>
+                  <label><input type="radio" name="hepatitis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hepatitis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Jaundice");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_jaundice() ){?>
+                  <label><input type="radio" name="jaundice" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="jaundice" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Hematochezia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hematochezia() ){?>
+                  <label><input type="radio" name="hematochezia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hematochezia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Changed Bowel");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_changed_bowel() ){?>
+                  <label><input type="radio" name="changed_bowel" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="changed_bowel" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Diarrhea");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_diarrhea() ){?>
+                  <label><input type="radio" name="diarrhea" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="diarrhea" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Constipation");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_constipation() ){?>
+                  <label><input type="radio" name="constipation" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="constipation" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Skin");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Cancer");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_s_cancer() ){?>
-                <label><input type="radio" name="s_cancer" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="s_cancer" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Genitourinary General");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Psoriasis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_psoriasis() ){?>
-                <label><input type="radio" name="psoriasis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="psoriasis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Acne");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_s_acne() ){?>
-                <label><input type="radio" name="s_acne" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="s_acne" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Other");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_s_other() ){?>
-                <label><input type="radio" name="s_other" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="s_other" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Disease");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_s_disease() ){?>
-                <label><input type="radio" name="s_disease" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="s_disease" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-        </div>
-      </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Psychiatric");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Psychiatric Diagnosis");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_p_diagnosis() ){?>
-                <label><input type="radio" name="p_diagnosis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="p_diagnosis" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Psychiatric Medication");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_p_medication() ){?>
-                <label><input type="radio" name="p_medication" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="p_medication" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Depression");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_depression() ){?>
-                <label><input type="radio" name="depression" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="depression" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Anxiety");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_anxiety() ){?>
-                <label><input type="radio" name="anxiety" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="anxiety" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Social Difficulties");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_social_difficulties() ){?>
-                <label><input type="radio" name="social_difficulties" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="social_difficulties" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Polyuria");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_polyuria() ){?>
+                  <label><input type="radio" name="polyuria" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="polyuria" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Polydypsia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_polydypsia() ){?>
+                  <label><input type="radio" name="polydypsia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="polydypsia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Dysuria");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_dysuria() ){?>
+                  <label><input type="radio" name="dysuria" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="dysuria" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Hematuria");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hematuria() ){?>
+                  <label><input type="radio" name="hematuria" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hematuria" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Frequency");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_frequency() ){?>
+                  <label><input type="radio" name="frequency" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="frequency" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Urgency");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_urgency() ){?>
+                  <label><input type="radio" name="urgency" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="urgency" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Incontinence");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_incontinence() ){?>
+                  <label><input type="radio" name="incontinence" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="incontinence" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Renal Stones");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_renal_stones() ){?>
+                  <label><input type="radio" name="renal_stones" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="renal_stones" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("UTIs");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_utis() ){?>
+                  <label><input type="radio" name="utis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="utis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Endocrine");?></h3>
-        </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Thyroid Problems");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_thyroid_problems() ){?>
-                <label><input type="radio" name="thyroid_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="thyroid_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Genitourinary Male");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Diabetes");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_diabetes() ){?>
-                <label><input type="radio" name="diabetes" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="diabetes" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
-          </div>
-          <div>
-            <?php echo xlt("Abnormal Blood Test");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_abnormal_blood() ){?>
-                <label><input type="radio" name="abnormal_blood" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="abnormal_blood" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Hesitancy");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hesitancy() ){?>
+                  <label><input type="radio" name="hesitancy" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hesitancy" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Dribbling");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_dribbling() ){?>
+                  <label><input type="radio" name="dribbling" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="dribbling" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Stream");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_stream() ){?>
+                  <label><input type="radio" name="stream" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="stream" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Nocturia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_nocturia() ){?>
+                  <label><input type="radio" name="nocturia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="nocturia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Erections");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_erections() ){?>
+                  <label><input type="radio" name="erections" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="erections" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Ejaculations");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_ejaculations() ){?>
+                  <label><input type="radio" name="ejaculations" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="ejaculations" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col-xs-6 col-sm-4 col-md-3 panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title"><?php echo xlt("Hematologic/Allergic/Immunologic");?></h3>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Genitourinary Female");?></h3>
+          </div>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Female G");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_g() ){?>
+                  <label><input type="radio" name="g" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="g" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Female P");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_p() ){?>
+                  <label><input type="radio" name="p" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="p" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Female AP");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_ap() ){?>
+                  <label><input type="radio" name="ap" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="ap" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Female LC");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_lc() ){?>
+                  <label><input type="radio" name="lc" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="lc" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <!-- The get_mearche function is mispelled -->
+            <div>
+              <?php echo xlt("Menarche");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_mearche() ){?>
+                  <label><input type="radio" name="mearche" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="mearche" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Menopause");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_menopause() ){?>
+                  <label><input type="radio" name="menopause" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="menopause" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("LMP");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_lmp() ){?>
+                  <label><input type="radio" name="lmp" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="lmp" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Frequency");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_f_frequency() ){?>
+                  <label><input type="radio" name="frequency" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="frequency" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Flow");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_f_flow() ){?>
+                  <label><input type="radio" name="f_flow" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="f_flow" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Symptoms");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_f_symptoms() ){?>
+                  <label><input type="radio" name="f_symptoms" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="f_symptoms" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Abnormal Hair Growth");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_abnormal_hair_growth() ){?>
+                  <label><input type="radio" name="abnormal_hair_growth" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="abnormal_hair_growth" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("F/H Female Hirsutism/Striae");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_f_hirsutism() ){?>
+                  <label><input type="radio" name="f_hirsutism" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="f_hirsutism" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+          </div>
         </div>
-        <div class="panel-body">
-          <div>
-            <?php echo xlt("Anemia");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_anemia() ){?>
-                <label><input type="radio" name="anemia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="anemia" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Musculoskeletal");?></h3>
           </div>
-          <div>
-            <?php echo xlt("F/H Blood Problems");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_fh_blood_problems() ){?>
-                <label><input type="radio" name="fh_blood_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="fh_blood_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Chronic Joint Pain");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_joint_pain() ){?>
+                  <label><input type="radio" name="joint_pain" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="joint_pain" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Swelling");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_swelling() ){?>
+                  <label><input type="radio" name="swelling" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="swelling" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Redness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_redness() ){?>
+                  <label><input type="radio" name="redness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="redness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Warm");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_m_warm() ){?>
+                  <label><input type="radio" name="m_warm" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="m_warm" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Stiffness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_m_stiffness() ){?>
+                  <label><input type="radio" name="m_stiffness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="m_stiffness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Muscle");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_muscle() ){?>
+                  <label><input type="radio" name="muscle" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="muscle" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Aches");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_m_aches() ){?>
+                  <label><input type="radio" name="m_aches" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="m_aches" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("FMS");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_fms() ){?>
+                  <label><input type="radio" name="fms" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="fms" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Arthritis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_arthritis() ){?>
+                  <label><input type="radio" name="arthritis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="arthritis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
-          <div>
-            <?php echo xlt("Bleeding Problems");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_bleeding_problems() ){?>
-                <label><input type="radio" name="bleeding_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="bleeding_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Neurologic");?></h3>
           </div>
-          <div>
-            <?php echo xlt("Allergies");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_allergies() ){?>
-                <label><input type="radio" name="allergies" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="allergies" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("LOC");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_loc() ){?>
+                  <label><input type="radio" name="loc" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="loc" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Seizures");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_seizures() ){?>
+                  <label><input type="radio" name="seizures" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="seizures" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Stroke");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_stroke() ){?>
+                  <label><input type="radio" name="stroke" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="stroke" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("TIA");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_tia() ){?>
+                  <label><input type="radio" name="tia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="tia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Numbness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_n_numbness() ){?>
+                  <label><input type="radio" name="n_numbness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="n_numbness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Weakness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_n_weakness() ){?>
+                  <label><input type="radio" name="n_weakness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="n_weakness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Paralysis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_paralysis() ){?>
+                  <label><input type="radio" name="paralysis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="paralysis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Intellectual Decline");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_intellectual_decline() ){?>
+                  <label><input type="radio" name="intellectual_decline" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="intellectual_decline" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Memory Problems");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_memory_problems() ){?>
+                  <label><input type="radio" name="memory_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="memory_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Dementia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_dementia() ){?>
+                  <label><input type="radio" name="dementia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="dementia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Headache");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_n_headache() ){?>
+                  <label><input type="radio" name="n_headache" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="n_headache" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
-          <div>
-            <?php echo xlt("Frequent Illness");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_frequent_illness() ){?>
-                <label><input type="radio" name="frequent_illness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="frequent_illness" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Skin");?></h3>
           </div>
-          <div>
-            <?php echo xlt("HIV");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hiv() ){?>
-                <label><input type="radio" name="hiv" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hiv" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Cancer");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_s_cancer() ){?>
+                  <label><input type="radio" name="s_cancer" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="s_cancer" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Psoriasis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_psoriasis() ){?>
+                  <label><input type="radio" name="psoriasis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="psoriasis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Acne");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_s_acne() ){?>
+                  <label><input type="radio" name="s_acne" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="s_acne" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Other");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_s_other() ){?>
+                  <label><input type="radio" name="s_other" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="s_other" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Disease");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_s_disease() ){?>
+                  <label><input type="radio" name="s_disease" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="s_disease" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
-          <div>
-            <?php echo xlt("HAI Status");?>:
-            <?php foreach ($this->form->get_options() as $value) {
-              if($value==$this->form->get_hai_status() ){?>
-                <label><input type="radio" name="hai_status" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
-              <?php } else {?>
-                <label><input type="radio" name="hai" value="<?php echo $value;?>"/><?php echo $value;?></label>
-              <?php }
-            }?>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Psychiatric");?></h3>
+          </div>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Psychiatric Diagnosis");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_p_diagnosis() ){?>
+                  <label><input type="radio" name="p_diagnosis" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="p_diagnosis" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Psychiatric Medication");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_p_medication() ){?>
+                  <label><input type="radio" name="p_medication" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="p_medication" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Depression");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_depression() ){?>
+                  <label><input type="radio" name="depression" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="depression" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Anxiety");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_anxiety() ){?>
+                  <label><input type="radio" name="anxiety" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="anxiety" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Social Difficulties");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_social_difficulties() ){?>
+                  <label><input type="radio" name="social_difficulties" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="social_difficulties" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Endocrine");?></h3>
+          </div>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Thyroid Problems");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_thyroid_problems() ){?>
+                  <label><input type="radio" name="thyroid_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="thyroid_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Diabetes");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_diabetes() ){?>
+                  <label><input type="radio" name="diabetes" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="diabetes" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Abnormal Blood Test");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_abnormal_blood() ){?>
+                  <label><input type="radio" name="abnormal_blood" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="abnormal_blood" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-6 col-sm-4 col-md-3">
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h3 class="panel-title"><?php echo xlt("Hematologic/Allergic/Immunologic");?></h3>
+          </div>
+          <div class="panel-body">
+            <div>
+              <?php echo xlt("Anemia");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_anemia() ){?>
+                  <label><input type="radio" name="anemia" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="anemia" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("F/H Blood Problems");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_fh_blood_problems() ){?>
+                  <label><input type="radio" name="fh_blood_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="fh_blood_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Bleeding Problems");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_bleeding_problems() ){?>
+                  <label><input type="radio" name="bleeding_problems" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="bleeding_problems" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Allergies");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_allergies() ){?>
+                  <label><input type="radio" name="allergies" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="allergies" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("Frequent Illness");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_frequent_illness() ){?>
+                  <label><input type="radio" name="frequent_illness" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="frequent_illness" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("HIV");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hiv() ){?>
+                  <label><input type="radio" name="hiv" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hiv" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
+            <div>
+              <?php echo xlt("HAI Status");?>:
+              <?php foreach ($this->form->get_options() as $value) {
+                if($value==$this->form->get_hai_status() ){?>
+                  <label><input type="radio" name="hai_status" value="<?php echo $value;?>" checked="checked" /><?php echo $value;?></label>
+                <?php } else {?>
+                  <label><input type="radio" name="hai" value="<?php echo $value;?>"/><?php echo $value;?></label>
+                <?php }
+              }?>
+            </div>
           </div>
         </div>
       </div>
       <div>
         <!-- Save/Cancel buttons -->
-        <input type="button" id="save" class='cp-submit' value="<?php echo xlt('Save'); ?>"> &nbsp;
-        <input type="button" id="dontsave" class="deleter cp-negative" value="<?php echo xlt('Cancel'); ?>"> &nbsp;
+        <input type="button" id="save" class='btn btn-success' value="<?php echo xlt('Save'); ?>"> &nbsp;
+        <input type="button" id="dontsave" class="deleter btn btn-danger" value="<?php echo xlt('Cancel'); ?>"> &nbsp;
       </div>
   </body>
 </html>

--- a/interface/forms/vitals/templates/vitals/general_new.php
+++ b/interface/forms/vitals/templates/vitals/general_new.php
@@ -7,7 +7,7 @@
     <?php 
       html_header_show();       
       // Include Bootstrap and datetimepicker
-      call_required_libraries(array("jquery-min-3-1-1","bootstrap","datepicker"));
+      call_required_libraries(array("jquery-min-3-1-1","bootstrap","datepicker", "font-awesome"));
     ?>
     <script type="text/javascript">
       var mypcc = '<?php echo $GLOBALS['phone_country_code']; ?>';
@@ -96,7 +96,8 @@
       
     </style>
   </head>
-  <body >
+  <body>
+    <a href="javascript:history.back()"><h4><i class="fa fa-chevron-left" id="backbutton" aria-hidden="true"></i> Back</h4></a>
     <p>
     <table class="table well">
       <tr>
@@ -663,8 +664,8 @@ echo $result['BMI_status'];
     <?php if($this->patient_age <= 20 || (preg_match('/month/', $this->patient_age))){?>
     <!-- only show growth-chart button for patients < 20 years old -->
     <!-- <input type="button" id="growthchart" value="{xl t="Growth-Chart"}" style='margin-left: 20px;'> -->
-    <input type="button" id="pdfchart" value="Growth-Chart (PDF)" style='margin-left: 20px;'>
-    <input type="button" id="htmlchart" value="Growth-Chart (HTML)" style='margin-left: 20px;'>
+    <input type="button" class="btn btn-primary" id="pdfchart" value="Growth-Chart (PDF)" style='margin-left: 20px;'>
+    <input type="button" class="btn btn-primary" id="htmlchart" value="Growth-Chart (HTML)" style='margin-left: 20px;'>
     <?php }?>
   </td>
 </tr>
@@ -674,8 +675,8 @@ echo $result['BMI_status'];
 </tr>
 <tr>
   <td colspan='3' style='text-align:center'>
-    <input type="submit" name="Submit" class='cp-submit' value="Save Form">
-    <input type="button" class="deleter cp-negative" id="cancel" value="Don't Save">
+    <input type="submit" name="Submit" class='btn btn-success' value="Save Form">
+    <input type="button" class="btn btn-danger" id="cancel" value="Cancel">
   </td>
 </tr>
 </table>


### PR DESCRIPTION
## Task: (No.5)
Link: Patient->Visits->Current->Clinical->Review of Systems
Work: - There’s a missing api.inc file. Fix this
Add a back button

Link:Patient->Visits->Current->Clinical->Review of Systems Checks
Work: - Add a back button
There’s a missing file error

Link: Patient->Visits->Current->Clinical->Speech dictation
Work: - change “Don’t Save” button to “Cancel” (red)
Padding between textareas

Link: Patient->Visits->Current->Clinical->Vitals
Work: - change “Don’t Save” button to “Cancel” (red)
Fix the missing file error

## Fixes
For **Patient->Visits->Current->Clinical->Review of Systems** and **Patient->Visits->Current->Clinical->Review of Systems>Checks**, the panels are restyled to look cleaner.
<img width="1247" alt="screen shot 2018-12-11 at 11 15 30" src="https://user-images.githubusercontent.com/28529491/49797841-95526100-fd38-11e8-98ef-e90633f8e4c2.png">

<img width="1669" alt="screen shot 2018-12-11 at 11 28 35" src="https://user-images.githubusercontent.com/28529491/49797851-9c796f00-fd38-11e8-92b4-b3ce38e2bf17.png">
FROM:
<img width="648" alt="screen shot 2018-12-11 at 09 47 59" src="https://user-images.githubusercontent.com/28529491/49797881-b74be380-fd38-11e8-8082-eb6eb6aa698f.png">

Also: api.inc link is no longer broken

#### A Back button is added for ALL PAGES
<img width="264" alt="screen shot 2018-12-11 at 11 34 57" src="https://user-images.githubusercontent.com/28529491/49797922-cf236780-fd38-11e8-82d8-e8d79de6945c.png">

#### Bootstrap buttons replace the usual buttons which were quite hard to read
<img width="471" alt="screen shot 2018-12-11 at 11 28 40" src="https://user-images.githubusercontent.com/28529491/49797933-d8accf80-fd38-11e8-9a4f-932db44bd082.png">

Finally, not a rant but just a suggestion. The theme data seems to contain margins and paddings. I believe that this is quite bad as there would not be a consistency in the theming. All themes should have the same borders and margin, some libraries like bootstrap would help. However, with these CSS margin in the files, the choice to use libraries such as bootstrap is not possible as these CSS properties would not complement with bootstrap containers and such. I decided to not remove this from the theme as it might break alot of pages already developed upon the theme

<img width="328" alt="screen shot 2018-12-11 at 11 28 03" src="https://user-images.githubusercontent.com/28529491/49798249-c1baad00-fd39-11e8-9a7e-4fa8fe931a84.png">
