### PR TITLE
Fixed cursor spacing on mouse focus in text area (New Encounter)

### DIFF
--- a/interface/forms/patient_encounter/common.php
+++ b/interface/forms/patient_encounter/common.php
@@ -167,9 +167,7 @@ function cancelClicked() {
  <div class="row">
   <div class="col-xs-12 col-sm-4 col-lg-4 ">
     <?php echo xlt('Consultation Brief Description'); ?>:
-    <textarea class="form-control input-sm" style="resize:none" name='reason' cols='40' rows='12' wrap='virtual'>
-      <?php echo $viewmode ? text($result['reason']) : text($GLOBALS['default_chief_complaint']); ?>
-    </textarea>
+    <textarea class="form-control input-sm" style="resize:none" name='reason' cols='40' rows='12' wrap='virtual'><?php echo $viewmode ? text($result['reason']) : text($GLOBALS['default_chief_complaint']); ?></textarea>
     <hr>  
   </div>
   <div class="col-xs-12 col-sm-4 col-lg-4 ">


### PR DESCRIPTION
Noticed on mouse focus the cursor moves some spaces ahead. Bringing the textarea tag to one line solves this issue
### Preview 
![screen shot 2019-01-21 at 8 16 36 am](https://user-images.githubusercontent.com/16350814/51458284-f1a39a00-1d54-11e9-9f55-ca7fbd136cd4.png)

