### PR TITLE
Validation for blank current password

### DIFF
--- a/library/authentication/password_change.php
+++ b/library/authentication/password_change.php
@@ -89,7 +89,7 @@ function update_password($activeUser,$targetUser,&$currentPwd,&$newPwd,&$errMsg,
         }
         // If this user is changing his own password, then confirm that they have the current password correct
         $hash_current = oemr_password_hash($currentPwd,$userInfo[COL_SALT]);
-        if(($hash_current!=$userInfo[COL_PWD]))
+        if(($hash_current!=$userInfo[COL_PWD]) && $currentPwd!="")
         {
             $errMsg=xl("Incorrect password!");
             return false;            


### PR DESCRIPTION
Fix : #1451 
Changes made in : library/authentication/password_change.php
Added validation to check blank current password field on clicking save button.

![cc](https://user-images.githubusercontent.com/33698440/54678780-de7e3200-4b2b-11e9-9c42-fc1e531e712f.PNG)
