### PR TITLE
Fixes incorrect property setting description

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1736,7 +1736,7 @@ $GLOBALS_METADATA = array(
       xl('Auto-Create New Encounters'),
        'bool',                          // data type
        '1',                             // default
-      xl('Automatically create a new encounter when an appointment check in status is selected.')
+      xl('Automatically create a new encounter when the "@ Arrived" appointment check-in status is selected.')
     ),
 
     'disable_pat_trkr' => array(


### PR DESCRIPTION
Fixes Issue #[1484](https://github.com/LibreHealthIO/lh-ehr/issues/1484).

The description for the "Auto-Create New Encounters" property now reads:
![fixed-property-description](https://user-images.githubusercontent.com/8771586/61681193-81151000-acda-11e9-81af-9bd3bd3adf1f.png)
