### PR TITLE
Flow Board - "Show Exam Room" Option Typo

### DIFF
--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -237,7 +237,7 @@ function topatient(newpid, enc) {
         <label><input type="checkbox" name="ptkr_show_pid" value="1" <?php if($GLOBALS['ptkr_show_pid']=='1') echo "checked"; ?>><?php echo xlt("Show Patient ID in Patient Flow Board"); ?></label>
         </div>
         <div class="checkbox">
-        <label><input type="checkbox" name="ptkr_show_room" value="1" <?php if($GLOBALS['ptkr_show_room']=='1') echo "checked"; ?>><?php echo xlt("Show Exam Room Patient Flow Board"); ?></label>
+        <label><input type="checkbox" name="ptkr_show_room" value="1" <?php if($GLOBALS['ptkr_show_room']=='1') echo "checked"; ?>><?php echo xlt("Show Exam Room in Patient Flow Board"); ?></label>
         </div>
         <div class="checkbox">
         <label><input type="checkbox" name="ptkr_show_visit_type" value="1" <?php if($GLOBALS['ptkr_show_visit_type']=='1') echo "checked"; ?>><?php echo xlt("Show Visit Type in Patient Flow Board"); ?></label>


### PR DESCRIPTION
The Flow Board option "Show Exam Room Patient Flow Board" was missing "in" and this was corrected to "Show Exam Room in Patient Flow Board".
The affected file is "/interface/patient_tracker/patient_tracker.php" on line 240.

![Flow Board Show Exam Room Typo](https://user-images.githubusercontent.com/56150011/66240316-e485da00-e72e-11e9-94b3-e04b123f56e8.png)

In the above figure, the option in red is the one with the typo.
