### PR TITLE
form no longer accepts invalid or empty dates

### DIFF
--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -141,11 +141,9 @@ foreach ( $appointments as $apt ) {
 <title><?php echo xlt("Flow Board") ?></title>
 <?php
     //  Include Bootstrap and DateTimePicker
-  call_required_libraries(array("jquery-min-3-1-1","bootstrap","datepicker"));
+  call_required_libraries(array("jquery-min-3-1-1","bootstrap","datepicker", "iziModalToast"));
 ?>
 <link rel='stylesheet' href='<?php echo $css_header ?>' type='text/css'>
-<link rel="stylesheet" href="../../assets/css/iziModalToast/iziToast.min.css" type="text/css">
-<script type="text/javascript" src="../../assets/js/iziModalToast/iziToast.min.js" type="text/javascript"></script>
 <script type="text/javascript" src="../../library/js/common.js"></script>
 <script type="text/javascript" src="../../library/js/blink/jquery.modern-blink.js"></script>
 <script language="JavaScript">
@@ -217,7 +215,7 @@ function validateForm() {
             if (fromDate > toDate) {
                 iziToast.warning({
                     title: 'Caution:',
-                    message:"<?php echo xls('The To date must be later than the From date.'); ?>",
+                    message:"<?php echo xls('You must enter a To date that is later than the From date.'); ?>",
                 });
                 return false;
             }

--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
 /**
  *  Patient Tracker (Patient Flow Board)
  *
@@ -143,29 +143,30 @@ foreach ( $appointments as $apt ) {
     //  Include Bootstrap and DateTimePicker
   call_required_libraries(array("jquery-min-3-1-1","bootstrap","datepicker"));
 ?>
-    <link rel='stylesheet' href='<?php echo $css_header ?>' type='text/css'>
-
+<link rel='stylesheet' href='<?php echo $css_header ?>' type='text/css'>
+<link rel="stylesheet" href="../../assets/css/iziModalToast/iziToast.min.css" type="text/css">
+<script type="text/javascript" src="../../assets/js/iziModalToast/iziToast.min.js" type="text/javascript"></script>
 <script type="text/javascript" src="../../library/js/common.js"></script>
 <script type="text/javascript" src="../../library/js/blink/jquery.modern-blink.js"></script>
 <script language="JavaScript">
 // Refresh self
 function refreshme() {
-  top.restoreSession();
-  document.pattrk.submit();
+    top.restoreSession();
+    document.pattrk.submit();
 }
 
 // popup for patient tracker status
 function bpopup(tkid) {
- top.restoreSession();
- window.open('../patient_tracker/patient_tracker_status.php?tracker_id=' + tkid ,'_blank', 'width=500,height=250,resizable=1');
- return false;
+    top.restoreSession();
+    window.open('../patient_tracker/patient_tracker_status.php?tracker_id=' + tkid ,'_blank', 'width=500,height=250,resizable=1');
+    return false;
 }
 
 // popup for calendar add edit
 function calendarpopup(eid,date_squash) {
- top.restoreSession();
- window.open('<?php echo $GLOBALS["web_root"]; ?>/modules/calendar/add_edit_event.php?eid=' + eid + '&date=' + date_squash,'_blank', 'width=775,height=400,resizable=1');
- return false;
+    top.restoreSession();
+    window.open('<?php echo $GLOBALS["web_root"]; ?>/modules/calendar/add_edit_event.php?eid=' + eid + '&date=' + date_squash,'_blank', 'width=775,height=400,resizable=1');
+    return false;
 }
 
 // auto refresh screen pat_trkr_timer is the timer variable AND IF settings aren't opened
@@ -182,9 +183,6 @@ function refreshbegin(first){
     } else {
         var expanded = document.getElementById("pat_settings_toggle").getAttribute('aria-expanded');
     }
-
-
-
 
     // expanded variable is the status of the pat_settings div. if it is opened, this variable will evaluate to true
     // otherwise, false. this can be used to check if options are opened
@@ -208,7 +206,41 @@ function topatient(newpid, enc) {
      }
 }
 
+// validate input submitted into the form in Flow Board
+function validateForm() {
+    var d = document.forms["theform"];
 
+    fromDate = d.form_from_date.value;
+    <?php if($GLOBALS['ptkr_date_range']) { ?>
+        toDate = d.form_to_date.value;
+        if (fromDate.length > 0 && toDate.length > 0) {
+            if (fromDate > toDate) {
+                iziToast.warning({
+                    title: 'Caution:',
+                    message:"<?php echo xls('The To date must be later than the From date.'); ?>",
+                });
+                return false;
+            }
+            return true;
+        } else {
+            iziToast.warning({
+                title: 'Caution:',
+                message:"<?php echo xls('You must enter a From and To date.'); ?>",
+            });
+            return false;
+        }
+    <?php } else { ?>
+        if (fromDate.length == 0) {
+            iziToast.warning({
+                title: 'Caution:',
+                message:"<?php echo xls('You must enter a date.'); ?>",
+            });
+            return false;
+        } else {
+            return true;
+        }
+    <?php } ?>
+}
 </script>
 
 </head>
@@ -303,7 +335,7 @@ function topatient(newpid, enc) {
         echo "</script>";
         }
     ?>
-<form method='post' name='theform' id='theform' action='<?php echo $action_page; ?>' onsubmit='return top.restoreSession()'>
+<form method='post' name='theform' id='theform' action='<?php echo $action_page; ?>' onsubmit='return validateForm()'>
     <div class="table-responsive">
         <table class="table well">
             <tr>
@@ -397,9 +429,9 @@ function topatient(newpid, enc) {
 <div id="flowboard_header">
   <?php if (count($chk_prov) == 1) {?>
     <?php if($GLOBALS['ptkr_date_range']) { ?>
-      <h3><?php echo xlt('Appointments for') . ' : '. text(reset($chk_prov)) . ' ' . ' : '. xlt('Date Range') . ' ' . text($form_from_date) . ' ' . xlt('to'). ' ' . text($form_to_date) ?></h3>
+      <h3><?php echo xlt('Appointments for ') . text(reset($chk_prov)) . ': '. xlt('Date Range') . ' ' . text($form_from_date) . ' ' . xlt('to'). ' ' . text($form_to_date) ?></h3>
     <?php } else { ?>
-      <h3><?php echo xlt('Appointments for'). ' : '. text(reset($chk_prov)) . ' : '. xlt('Date') . ' ' . text($form_from_date) ?></h3>
+      <h3><?php echo xlt('Appointments for ') . text(reset($chk_prov)) . ': '. xlt('Date') . ' ' . text($form_from_date) ?></h3>
     <?php } ?>
   <?php } else { ?>
     <?php if($GLOBALS['ptkr_date_range']) { ?>


### PR DESCRIPTION
Fixes Issue #1514 

Now, using iziToast, when a user enters a From date greater than a To date or submits the Flow Board form without a date(s), a warning message pops up to let the user know without submitting the form:

Examples:
1) User submits the form with 2019-10-01 to 2019-09-04 date range:
![invalid-date-range-resolved-w-outline-size](https://user-images.githubusercontent.com/8771586/66263881-3dee1780-e7c8-11e9-8aae-ea4a7eb45a29.png)

2) User submits form without specifying a date:
![empty-date-resolved-w-outline-size](https://user-images.githubusercontent.com/8771586/66263886-52321480-e7c8-11e9-9603-75b08bcea2b4.png)
