### PR TITLE
Fixes Issue #1523 - added missing word in setting description

### DIFF
--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -246,7 +246,7 @@ function topatient(newpid, enc) {
         <label><input type="checkbox" name="ptkr_show_encounter" value="1" <?php if($GLOBALS['ptkr_show_encounter']=='1') echo "checked"; ?>><?php echo xlt("Show Patient Encounter Number in Patient Flow Board"); ?></label>
         </div>
         <div class="checkbox">
-        <label><input type="checkbox" name="ptkr_flag_dblbook" value="1" <?php if($GLOBALS['ptkr_flag_dblbook']=='1') echo "checked"; ?>><?php echo xlt("Flag Double Booked Appt in Flow Board"); ?></label>
+        <label><input type="checkbox" name="ptkr_flag_dblbook" value="1" <?php if($GLOBALS['ptkr_flag_dblbook']=='1') echo "checked"; ?>><?php echo xlt("Flag Double Booked Appt in Patient Flow Board"); ?></label>
         </div>
         <div class="checkbox">
         <label><input type="checkbox" name="ptkr_date_range" value="1" <?php if($GLOBALS['ptkr_date_range']=='1') echo "checked"; ?>><?php echo xlt("Allow Date Range in Patient Flow Board"); ?></label>


### PR DESCRIPTION
The sixth property setting within the Flow Board Local Settings now says, "Flag Double Booked Appt in Patient Flow Board." This change makes it consistent with the other property setting descriptions.

![missing-word-fixed-w-outline](https://user-images.githubusercontent.com/8771586/66362827-2e023f00-e952-11e9-9e22-0deadb2f1a55.png)


