### PR TITLE
Fixes Arrow icons overlapped by text on ‘Previous’ and ‘Next’ Buttons on Patient Finder

### DIFF
--- a/interface/themes/style_tan.css
+++ b/interface/themes/style_tan.css
@@ -655,6 +655,8 @@ tr.odd {
   border-radius: 5px;
   font-size:0.8em;
   box-shadow: 2px 1px 4px #88888B;
+  width: 80px;
+  text-align: center;
 }
 .css_button span, input[type="button"] span, button span {
   display: inline-block;


### PR DESCRIPTION
this commit fixes #1412

A) Outreachy Username: j-pro 
B) Issue title: Arrow icons overlapped by text on ‘Previous’ and ‘Next’ Buttons on Patient Finder  
C) Report Date: Oct 26, 2019  
D) Sites Affected: Documentation Site 
E) OS/ browser used: Windows / Chrome, Firefox 
F) EHR Workflow module: Patient Finder 
G) Steps to Reproduce the Issue:  

1. Login with your account credentials. 
2. In the top navigation, take your cursor to ‘Patient/Client’. 
3. A dropdown menu will appear.  Click on ‘Finder’. 
4. ‘Patient Finder’ will open.  Scroll till the end where you find ‘Previous’ and ‘Next’ Buttons. 

H) Expected Behavior: There should be some space between the icon and text of the Buttons, so that both the text and icon can be clearly seen.  

I) What Actually Happened: The icon and text are overlapped in both the ‘Next’ and ‘Previous’ Buttons, causing some difficulties in reading the text. 

J) Screenshots with Explanation:  

 ![npb-01](https://user-images.githubusercontent.com/1905329/68075976-214cfb80-fdd7-11e9-91b5-6b7af106a39a.png)
The ‘Next’ and ‘Previous’ Buttons have text and icon overlapped. 
 

![npb-02](https://user-images.githubusercontent.com/1905329/68075978-214cfb80-fdd7-11e9-9128-1248125cb009.png)
The highlighted code represents the ‘Next’ Button.  

K) Estimation of Severity: 
Minor:  It is somehow distracting or confusing but workflow can continue correctly.  

L) Solution:  
 
I think the width of the Buttons is not defined, so they are taking only the width of text, excluding the arrow icons.  
 
![npb-03](https://user-images.githubusercontent.com/1905329/68075979-214cfb80-fdd7-11e9-9251-aa7cb4861184.png) 
I tried adding `width: 80px`.  The ‘Next’ text appeared in the right side and still got overlapped to the icon.  So I center aligned the text as shown in screenshot, and it seems to be the solution for now. 
 





