### PR TITLE
removed white spaces in menu header (fixes Issue #1536)

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -148,7 +148,7 @@ var webroot_url="<?php echo $web_root; ?>";
 </style>
 <div id="mainBox">
     <div id="dialogDiv"></div>
-    <div class="navbar-header">
+    <div class="navbar-header" id="navbar-header">
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
         <span class="sr-only"><?php echo xlt("Toggle navigation"); ?></span>
         <span class="icon-bar"></span>

--- a/interface/themes/style.php
+++ b/interface/themes/style.php
@@ -64,10 +64,9 @@ else {
 	$button_font_color = $secondary_font_color;
 }
 
-echo " .body_title, .body_top, .body_nav, .body_filler, .body_login, .table_bg, .bgcolor2, .textcolor1, .highlightcolor, .logobar, .dropdown-menu>li>a, .dropdown-toggle, #menu, .dropdown, .nav>li>a, .glyphicon, #userdata .dropdown-menu>li, #userdata{
+echo " .body_title, .body_top, .body_nav, .body_filler, .body_login, .table_bg, .bgcolor2, .textcolor1, .highlightcolor, .logobar, .dropdown-menu>li>a, .dropdown-toggle, #menu, .dropdown, .nav>li>a, .glyphicon, #userdata .dropdown-menu>li, #navbar-collapse, #navbar-header, #menu>ul, #userdata>li>a>h4 {
   background-color:  #$primary_color;
   color: #$primary_font_color;
-
 }
 
 .table, .bgcolor1,  ul.tabNav, .navbar, .nav, .dropdown, .navbar-header, ul.tabNav a, .navbar-collapse{


### PR DESCRIPTION
The white spaces (which is actually the primary color chosen in the Global settings) in the menu header and around the user's name have been removed and no longer show no matter the screen size. It now looks like this:

Full Screen View
![uniform-color-full-screen](https://user-images.githubusercontent.com/8771586/71935883-f637ad00-3175-11ea-9c72-1d059d25e72a.png)

Less than Full Screen but Menu isn't Hidden View
![uniform-color-not-full-view](https://user-images.githubusercontent.com/8771586/71935919-0780b980-3176-11ea-8903-ac0bbf8a584f.png)

Hidden Menu View
![uniform-color-mobile-view](https://user-images.githubusercontent.com/8771586/71936113-88d84c00-3176-11ea-8d90-96150722f1ac.png)



