### PR TITLE
Added missing labels and fixed form alignment

### DIFF
--- a/interface/billing/sl_receipts_report.php
+++ b/interface/billing/sl_receipts_report.php
@@ -187,7 +187,7 @@ function sel_diagnosis() {
                     $query = "select id, lname, fname from users where " .
                         "authorized = 1 order by lname, fname";
                     $res = sqlStatement($query);
-                    echo "   &nbsp;<select name='form_doctor'>\n";
+                    echo "   <select name='form_doctor'>\n";
                     echo "    <option value=''>-- " . xlt('All Providers') . " --\n";
                     while ($row = sqlFetchArray($res)) {
                         $provid = $row['id'];
@@ -200,6 +200,9 @@ function sel_diagnosis() {
                     echo "<input type='hidden' name='form_doctor' value='" . attr($_SESSION['authUserID']) . "'>";
                 }
             ?>
+            </td>
+            <td class='label'>
+               <?php echo xlt('Sort By Date'); ?>:
             </td>
             <td>
                <select name='form_use_edate'>

--- a/interface/reports/collections_report.php
+++ b/interface/reports/collections_report.php
@@ -173,6 +173,9 @@ function checkAll(checked) {
               <tr>
                 <?php // Show from and to dates. (TRK)  
                   showFromAndToDates(); ?>
+                <td class='label'>
+                  <?php echo xlt('Account Type'); ?>:
+                </td>
                 <td>
                   <select name='form_category'>
                   <?php

--- a/interface/reports/receipts_by_method_report.php
+++ b/interface/reports/receipts_by_method_report.php
@@ -124,7 +124,7 @@ function sel_procedure() {
     <table class='text'>
         <tr>
             <td class='label'>
-               <?php xl('Report by','e'); ?>
+               <?php echo xl('Report By','e'); ?>:
             </td>
             <td>
                 <?php
@@ -134,26 +134,33 @@ function sel_procedure() {
                   if ($key == $form_report_by) echo ' selected';
                   echo ">" . xl($value) . "</option>\n";
                 }
-                echo "   </select>&nbsp;\n"; ?>
+                echo "   </select>\n"; ?>
             </td>
 
+            <td class='label'>
+              <?php echo xlt('Facility'); ?>:
+            </td>
             <td>
             <?php dropdown_facility(strip_escape_custom($form_facility), 'form_facility', false); ?>
             </td>
 
-            <td>
+            <td class='label'>
                <?php if (!$GLOBALS['simplified_demographics']) echo '&nbsp;' . xl('Procedure/Service') . ':'; ?>
             </td>
             <td>
                <input type='text' name='form_proc_codefull' size='12' value='<?php echo $form_proc_codefull; ?>' onclick='sel_procedure()'
                 title='<?php xl('Click to select optional procedure code','e'); ?>'
                 <?php if ($GLOBALS['simplified_demographics']) echo "style='display:none'"; ?> />
-                                <br>
-               &nbsp;<input type='checkbox' name='form_details' value='1'<?php if ($_POST['form_details']) echo " checked"; ?> /><?xl('Details','e')?>
+            </td>
+            <td>
+              &nbsp;<label><input type='checkbox' name='form_details' value='1'<?php if ($_POST['form_details']) echo " checked"; ?> />
+              <?php echo xl('Details','e'); ?></label>
             </td>
         </tr>
         <tr>
-            <td>&nbsp;</td>
+            <td class='label'>
+              <?php echo xlt('Sort By Date'); ?>:
+            </td>
             <td>
                <select name='form_use_edate'>
                 <option value='0'><?php xl('Payment Date','e'); ?></option>
@@ -162,6 +169,7 @@ function sel_procedure() {
             </td>
             <?php // Show From and To dates fields. (TRK)
               showFromAndToDates(); ?>
+            <td>&nbsp;</td>
         </tr>
     </table>
 

--- a/interface/reports/services_by_category.php
+++ b/interface/reports/services_by_category.php
@@ -74,6 +74,9 @@ require_once "reports_controllers/ServiceByCategoryController.php";
 
 	<table class='text'>
 		<tr>
+         <td class='label'>
+            <?php echo xlt('Code Category'); ?>:
+         </td>
 			<td>
 			   <select name='filter'>
 				<option value='0'><?php xl('All','e'); ?></option>


### PR DESCRIPTION
Fixes Issues #1556 && #1557 

Added missing labels that were missing next to specific form elements in certain Report forms.

The "Receipts Summary" module now looks like this:
![receipts-summary-after](https://user-images.githubusercontent.com/8771586/75828866-d76f2480-5d7a-11ea-94bb-800644b53889.png)
