### PR TITLE
modified grant_priviledges function for mysql8

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -146,7 +146,16 @@ class Installer
   }
 
   public function grant_privileges() {
+	$version =  mysqli_get_server_version($this->dbh);
+	if($version >= 80000){
+		$this->execute_sql("drop user $this->login@$this->loginhost");
+		$this->execute_sql("FLUSH PRIVILEDGES");
+		return ( ($this->execute_sql("CREATE USER '$this->login'@'$this->loginhost' IDENTIFIED with mysql_native_password  by '$this->pass'"))
+		&&($this->execute_sql("GRANT ALL PRIVILEGES ON $this->dbname.* TO '$this->login'@'$this->loginhost'")));
+	}
+	else{
     return $this->execute_sql( "GRANT ALL PRIVILEGES ON $this->dbname.* TO '$this->login'@'$this->loginhost' IDENTIFIED BY '$this->pass'" );
+		}
   }
 
   public function disconnect() {


### PR DESCRIPTION
In mysql8 you need to create a user first before granting it privileges and I had to use mysql_native-password for it to connect to the database 