### PR TITLE
Fixed text on button changing to white after clicking button

### DIFF
--- a/interface/themes/style_tan.css
+++ b/interface/themes/style_tan.css
@@ -673,7 +673,7 @@ tr.odd {
 }
 /* set the text color inside button to white when it is visisted or hovered */
 .css_button:visited{
-	color:white;
+	color:brown;
 }
 .css_button:hover{
 	color:white;


### PR DESCRIPTION
@Ngai-E @mhn94  @muarachmann this is a fix for #1576. The text is now visible because I used a brown color. See screenshot below.
![image](https://user-images.githubusercontent.com/60817596/77236397-658e3c00-6bbe-11ea-8e27-95c2793b7c55.png)

