### PR TITLE
Fix in Patient Issues Showing Incorrect Date

### DIFF
--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -285,8 +285,8 @@ foreach ($ISSUE_TYPES as $focustype => $focustitles) {
 
     echo " <tr class='$bgclass detail' $colorstyle>\n";
     echo "  <td style='text-align:left' data-text='$disptitle' class='$click_class' id='$rowid'>" . text($disptitle) . "</td>\n";
-    echo "  <td>" . text(date(DateFormatRead(true), strtotime($row['begdate']))) . "&nbsp;</td>\n";
-    echo "  <td>" . text(date(DateFormatRead(true), strtotime($row['enddate']))) . "&nbsp;</td>\n";
+    echo "  <td>" . text($row['begdate']) . "&nbsp;</td>\n";
+    echo "  <td>" . text($row['enddate']) . "&nbsp;</td>\n";
     // both codetext and statusCompute have already been escaped above with htmlspecialchars)
     echo "  <td>" . $codetext . "</td>\n";
     echo "  <td>" . $statusCompute . "&nbsp;</td>\n";


### PR DESCRIPTION
This is  a fix in issue #1555. The Patient 'Issues' now does not display incorrect date without entry.