### PR TITLE
begin work on csrf fixes

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -41,6 +41,9 @@ else {
   session_regenerate_id(false);
 }
 
+//generate csrf token
+$_SESSION['token'] = generateCsrfToken();
+
 $_SESSION["encounter"] = '';
 
 // Fetch the password expiration date

--- a/interface/patient_file/letter.php
+++ b/interface/patient_file/letter.php
@@ -90,6 +90,14 @@ $patdata = sqlQuery("SELECT " .
 
 $alertmsg = ''; // anything here pops up in an alert box
 
+if (!empty($_POST)) {
+    if (!isset($_POST['token'])) {
+        error_log('WARNING: A Post detected with not csrf token found');
+        die('Authentication failed.');
+    } else if (!hash_equals(hash_hmac('sha256', '/letter.php.theform', $_SESSION['token']), $_POST['token'])) {
+        die('Authentication failed.');
+    }
+}
 // If the Generate button was clicked...
 if ($_POST['formaction']=="generate") {
 
@@ -430,6 +438,7 @@ function insertAtCursor(myField, myValue) {
 <form method='post' action='letter.php' id="theform" name="theform">
 <input type="hidden" name="formaction" id="formaction" value="">
 <input type='hidden' name='form_pid' value='<?php echo $pid ?>' />
+<input type='hidden' name='token' value="<?php echo hash_hmac('sha256', '/letter.php.theform', $_SESSION['token']);?>" />
 
 <center>
 <p>

--- a/library/sanitize.inc.php
+++ b/library/sanitize.inc.php
@@ -55,5 +55,34 @@ function image_has_right_size($size) {
   return $size < 20971520;
 }
 
+// Generate csrf token for authentication
+function generateCsrfToken()
+{
+    if (!extension_loaded('openssl')) {
+      error_log("ERROR: openssl extension not enabled, needed for proper functioning of LibreHealth");
+        die("Error: Systems needs openssl.");
+    }
+
+    $csrfToken = bin2hex(openssl_random_pseudo_bytes(32));
+
+    if (empty($csrfToken)) {
+        error_log("ERROR : Token generation failed");
+        die("Error : Unable to correctly generate token");
+    }
+
+    return $csrfToken;
+}
+
+// Function to verify a csrf token
+function verifyCsrfToken($token)
+{
+    if (hash_equals($_SESSION['token'], $token)) {
+        return true;
+    } else {
+        error_log("WARNING : Malicious attempt encountered");
+        return false;
+    }
+}
+
 
 ?>


### PR DESCRIPTION
This is the first test commit towards fixing the csrf vulnerability. Basically, we create a token to validate requests that can manipulate data on the system and verify this each time such request is made. 

This approach makes use of the openssl php extension which can be activated as follows;
1. Open php.ini file located under php installation folder.
2. Search for extension=php_openssl.dll.
3. Uncomment it by removing the semi-colon(;) in front of it.
4. Restart the Apache Server.

So far only the letter.php endpoint has been handled. More commits to come.