### PR TITLE
Prevent unauthenticated info disclosure in certain files

### DIFF
--- a/gacl/setup.php
+++ b/gacl/setup.php
@@ -5,6 +5,9 @@ $config_file = dirname(__FILE__).'/gacl.ini.php';
 require_once(dirname(__FILE__).'/admin/gacl_admin.inc.php');
 require_once(ADODB_DIR .'/adodb-xmlschema.inc.php');
 
+// check if user is authenticated before displaying setup info
+$setupCheck = true;
+require_once('../interface/globals.php');
 
 $db_table_prefix = $gacl->_db_table_prefix;
 $db_type = $gacl->_db_type;

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -132,8 +132,14 @@ if (empty($_SESSION['site_id']) || !empty($_GET['site'])) {
   }
   else {
     if (empty($ignoreAuth)) {
-        header('Location: login/login.php?loginfirst&site='.$tmp);
-        die();
+        if (isset($setupCheck) && ($setupCheck == true)) {
+          header('Location: ../interface/login/login.php?loginfirst&site='.$tmp);
+          die();
+        }
+        else {
+          header('Location: login/login.php?loginfirst&site='.$tmp);
+          die();
+        }
     }
     $tmp = $_SERVER['HTTP_HOST'];
     if (!is_dir($GLOBALS['OE_SITES_BASE'] . "/$tmp")) $tmp = "default";

--- a/sql_patch.php
+++ b/sql_patch.php
@@ -14,8 +14,6 @@
 // Disable PHP timeout.  This will not work in safe mode.
 ini_set('max_execution_time', '0');
 
-$ignoreAuth = true; // no login required
-
 require_once('interface/globals.php');
 require_once('library/sql.inc');
 require_once('library/sql_upgrade_fx.php');


### PR DESCRIPTION
`sql_patch.php` and `gacl/setup.php` both display setup info that can be accessed without any authentication as long as the user knows the url. This fix ensures the user has already been logged in before displaying the info. Otherwise, it redirects to the login page.