### PR TITLE
removed sensitive info output in backup.php

### DIFF
--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -575,7 +575,7 @@ if ($cmd) {
          $res=sqlStatement("drop table if exists log");
          $res=sqlStatement("rename table log_backup to log");
      }
-    die("\"$cmd\" returned $tmp2: $tmp0");
+    die("Return Status: $tmp2, Output: $tmp0");
   }
   //  ViSolve:  If the Eventlog is set, then clear the temporary table  -- Start here
   if ($eventlog==1)       {
@@ -639,7 +639,7 @@ function create_tar_archive($archiveName, $compressMethod, $itemArray) {
     $command = "tar -cpf $archiveName $files";
    }
    $temp0 = exec($command, $temp1, $temp2);
-   if ($temp2) die("\"$command\" returned $temp2: $temp0");
+   if ($temp2) die("Return Status: $temp2, Output: $temp0");
    return true;
   }
   return false;


### PR DESCRIPTION
This is a fix for [Issue 1372](https://github.com/LibreHealthIO/lh-ehr/issues/1372).

Locally, none of the warnings get displayed and backup.php seems to be in the right location according to the URL shown, so my fix targets the security aspect. 

I didn’t see any permission issues from the log reporting options on the server as suggested in the issue report, since the `$cmd` variable in the line of code below from backup.php is responsible for displaying the sensitive info:

`die("\"$cmd\" returned $tmp2: $tmp0");`

I wasn’t sure if displaying the command was imperative. I assumed no since it wasn’t mentioned in the issue report. Thus, my solution removed `$cmd` from the output.