### PR TITLE
 Fix the short tabs issue in the browser in windows

### DIFF
--- a/interface/main/tabs/css/tabs.css
+++ b/interface/main/tabs/css/tabs.css
@@ -23,7 +23,6 @@ body
     font-size: 10pt;
     flex: 1 0 auto;
     display: flex;
-    flex-direction: column;
 }
 #mainBox
 {


### PR DESCRIPTION
closes #1666 
Updates tabs.css
(Removes the "flex-direction: column;" in the body section of tabs.css to get rid of short tabs in the browser in windows and gives long screen length tabs)